### PR TITLE
Update electron-builder npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "AGPL-3.0-only",
   "devDependencies": {
     "electron": "^11.2.0",
-    "electron-builder": "^22.9.1",
+    "electron-builder": "^22.11.7",
     "eslint": "^7.21.0",
     "jest": "^26.6.3"
   },


### PR DESCRIPTION
This allows for the UI to be built specifically for Apple Silicon.