### PR TITLE
Now sets the file permissions after downloading or updating the binaries, 

### DIFF
--- a/modules/BinaryUpdater.js
+++ b/modules/BinaryUpdater.js
@@ -32,6 +32,7 @@ class BinaryUpdater {
             console.log("Downloading missing yt-dlp binary.");
             this.win.webContents.send("binaryLock", {lock: true, placeholder: `Installing yt-dlp version: ${remoteVersion}. Preparing...`})
             await this.downloadUpdate(remoteUrl, remoteVersion);
+            this.paths.setPermissions()
         } else if(remoteVersion == null) {
             transaction.setTag("download", "down");
             console.log("Unable to check for new updates, GitHub may be down.");
@@ -41,6 +42,7 @@ class BinaryUpdater {
             this.action = "Updating to";
             this.win.webContents.send("binaryLock", {lock: true, placeholder: `Updating yt-dlp to version: ${remoteVersion}. Preparing...`})
             await this.downloadUpdate(remoteUrl, remoteVersion);
+            this.paths.setPermissions()
         }
         span.finish();
         transaction.finish();


### PR DESCRIPTION
Fixes #262

I tested this by cleaning the binaries folder and running `npm run start`. I am not 100% sure that it is also needed after an update, but it also cannot hurt 😄 