### PR TITLE
try to get m4a along with mp4

### DIFF
--- a/modules/download/DownloadQuery.js
+++ b/modules/download/DownloadQuery.js
@@ -70,7 +70,7 @@ class DownloadQuery extends Query {
                     }
                 } else {
                     format = `
-                    bestvideo[height=${this.format.height}][fps=${this.format.fps}][ext=mp4]${encoding}+${this.video.audioQuality}audio${audioEncoding}
+                    bestvideo[height=${this.format.height}][fps=${this.format.fps}][ext=mp4]${encoding}+${this.video.audioQuality}audio[ext=m4a]${audioEncoding}
                     /bestvideo[height=${this.format.height}][fps=${this.format.fps}]${encoding}+${this.video.audioQuality}audio${audioEncoding}
                     /bestvideo[height=${this.format.height}][fps=${this.format.fps}]${encoding}+${this.video.audioQuality}audio
                     /bestvideo[height=${this.format.height}][fps=${this.format.fps}]+${this.video.audioQuality}audio
@@ -80,7 +80,7 @@ class DownloadQuery extends Query {
                     /best`;
                     if (this.format.fps == null) {
                         format = `
-                        bestvideo[height=${this.format.height}][ext=mp4]${encoding}+${this.video.audioQuality}audio${audioEncoding}
+                        bestvideo[height=${this.format.height}][ext=mp4]${encoding}+${this.video.audioQuality}audio[ext=m4a]${audioEncoding}
                         /bestvideo[height=${this.format.height}]${encoding}+${this.video.audioQuality}audio${audioEncoding}
                         /bestvideo[height=${this.format.height}]${encoding}+${this.video.audioQuality}audio
                         /bestvideo[height=${this.format.height}]+${this.video.audioQuality}audio

--- a/modules/download/DownloadQuery.js
+++ b/modules/download/DownloadQuery.js
@@ -38,6 +38,9 @@ class DownloadQuery extends Query {
             if(this.video.selectedAudioEncoding !== "none") {
                 args.push("-f");
                 args.push("bestaudio[acodec=" + this.video.selectedAudioEncoding + "]/bestaudio");
+            } else if(audioOutputFormat === "m4a") {
+                args.push("-f");
+                args.push("bestaudio[ext=m4a]/bestaudio");
             }
             if(audioOutputFormat !== "none") {
                 args.push('--audio-format', audioOutputFormat);


### PR DESCRIPTION
Related to #258 & b1b3d67ef420e9ecc5ae606964055f7e83b04db7
And add a preference for m4a if audio-only output is set to be m4a, to avoid conversion from other codec.

currently
```
-f bestvideo[ext=mp4]+bestaudio
Downloading 1 format(s): 137+251
WARNING: Requested formats are incompatible for merge and will be merged into mkv
```

with PR
```
-f bestvideo[ext=mp4]+bestaudio[ext=m4a]
Downloading 1 format(s): 137+140
```