### PR TITLE
Handle GitHub changes to fetch latest `yt-dlp`

### DIFF
--- a/modules/BinaryUpdater.js
+++ b/modules/BinaryUpdater.js
@@ -72,11 +72,11 @@ class BinaryUpdater {
                 return null;
             }
             if (res.status === 302) {
-                const versionRegex = res.data.match(/[0-9]+\.[0-9]+\.[0-9]+/);
-                const urlRegex = res.data.match(/(?<=").+?(?=")/);
+                const redirectUrl = res.headers.location;
+                const versionRegex = redirectUrl.match(/[0-9]+\.[0-9]+\.[0-9]+/);
                 return {
                     remoteVersion: versionRegex ? versionRegex[0] : null,
-                    remoteUrl: urlRegex ? urlRegex[0] : null,
+                    remoteUrl: redirectUrl,
                 };
             } else {
                 console.error('Did not get redirect for the latest version link. Status: ' + err.response.status);

--- a/tests/BinaryUpdater.test.js
+++ b/tests/BinaryUpdater.test.js
@@ -67,7 +67,6 @@ describe('getRemoteVersion', () => {
         const axiosGetSpy = jest.spyOn(axios, 'get').mockRejectedValue({
             response: {
                 status: 302,
-                data: "<a href=\"https://github.com/yt-dlp/yt-dlp/releases/download/2021.10.10/yt-dlp.exe\">",
                 headers: {
                     location: redirectURL
                 }


### PR DESCRIPTION
## Issue
GitHub has removed the response body when redirecting a user during release downloads which has broken the `yt-dlp` runtime download.  This is causing first time executions of the application to not download `yt-dlp` and return "Error! Binaries missing/corrupted" in the UI.

## Background
The approach to grab the latest version of `yt-dlp` was relying on GitHub to return the redirect URL in the body response when fetching the latest binary. GitHub has changed to no longer return the URL in the response body and is only emitting it in the `Location` header now.

## This PR
This PR is changing the logic to read the version from the `Location` header during the redirect.

In my testing the application now correctly detects the latest version number for `yt-dlp` and downloads it correctly.

## After screenshot
![image](https://user-images.githubusercontent.com/48865951/172784214-3a8f0646-ea4f-4ac8-b67d-27f5d949ce13.png)

## ytdlVersion file
`{"version":"2022.05.18","ytdlp":true}`