### PR TITLE
Remove `windows-32` ffmpeg download

### DIFF
--- a/modules/FfmpegUpdater.js
+++ b/modules/FfmpegUpdater.js
@@ -69,7 +69,6 @@ class FfmpegUpdater {
         try {
             const res = await axios.get("https://ffbinaries.com/api/v1/version/latest");
             let platform = "windows-64";
-            if (os.arch() === "x32" || os.arch() === "ia32") platform = "windows-32";
             if (process.platform === "darwin") platform = "osx-64";
             else if (process.platform === "linux") platform = "linux-32";
             return {
@@ -86,7 +85,7 @@ class FfmpegUpdater {
         }
     }
 
-    //Returns the currently downloaded version of yt-dlp
+   //Returns the currently downloaded version of yt-dlp
    async getLocalVersion() {
         let data;
         try {

--- a/tests/FfmpegUpdater.test.js
+++ b/tests/FfmpegUpdater.test.js
@@ -58,7 +58,7 @@ describe('getRemoteVersion', () => {
     });
     it('returns object with the links and the version', async () => {
         const axiosGetSpy = jest.spyOn(axios, 'get').mockResolvedValue({
-            data: { version: "4.2.1", bin: { "windows-32": { ffmpeg: "ffmpeg/link", ffprobe: "ffprobe/link" } } },
+            data: { version: "4.4.1", bin: { "windows-64": { ffmpeg: "ffmpeg/link", ffprobe: "ffprobe/link" } } },
         });
         jest.spyOn(os, 'arch').mockReturnValue('ia32');
         Object.defineProperty(process, "platform", {
@@ -69,7 +69,7 @@ describe('getRemoteVersion', () => {
         expect(result).toEqual({
             remoteFfmpegUrl: "ffmpeg/link",
             remoteFfprobeUrl: "ffprobe/link",
-            remoteVersion: "4.2.1"
+            remoteVersion: "4.4.1"
         });
         expect(axiosGetSpy).toBeCalledTimes(1);
     });


### PR DESCRIPTION
## Issue
When `os.arch()` == `ia32` we try to download `windows-32` ffmpeg but on ffbinaries it no longer exists: https://ffbinaries.com/api/v1/version/latest

From investigation, this is by design on their end and they will not provide 32-bit Windows binaries anymore.

On the Windows 11 x64 machine I am building on, `os.arch()` is returning `ia32` and `os.platform()` returns `win32` which is leading to ffmpeg to not automatically download as it attempts to download the `windows-32` binary.

`os.arch()` and `os.platform()` from console.log:
![image](https://user-images.githubusercontent.com/48865951/173017913-f4b0177c-6445-4903-bec5-7792da3be3a1.png)

But this is a 64-bit machine:
![image](https://user-images.githubusercontent.com/48865951/173018478-c66ee58f-f27a-44dd-b6ba-b68029bf6659.png)

## This change
This PR is removing `windows-32` ffmpeg downloading since the link doesn't exist anymore. On my local Windows 11 x64 machine, it is now successfully downloading ffmpeg automatically from `windows-64`. 

We could also find a new source for 32-bit Windows ffmpeg but from my investigation, the usage of 32-bit Windows is low.
At least on Steam, 32-bit Windows is only 0.18% of Windows machines: https://store.steampowered.com/hwsurvey/  

0.18% = `(0.12+0.05)*100/96.68`

## Tests
![image](https://user-images.githubusercontent.com/48865951/173018191-2c08376c-2d20-4ed0-b9af-b79ebe3852fa.png)
