### PR TITLE
feat(settings): toggle for restricted filenames

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -164,6 +164,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -725,6 +726,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -768,6 +770,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2100,6 +2103,7 @@
       "integrity": "sha512-JCs+MqoXfXrRPGbGmho/zGS/jMcn3ieKl/A8YImqib76C8kjgZwq5uUFzc30lJkMvcchuRn6/v8IApLxli3Jyw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.0",
         "@typescript-eslint/types": "^8.47.0",
@@ -2749,6 +2753,7 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -3423,6 +3428,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3721,6 +3727,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -4258,6 +4265,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4333,6 +4341,7 @@
       "integrity": "sha512-TsoFluWxOpsJlE/l2jJygLQLWBPJ3Qdkesv7tBIunICbTcG0dS1/NBw/Ol4tJw5kHWlAVds4lUmC29/vlPUcEQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "natural-compare": "^1.4.0",
@@ -5362,7 +5371,6 @@
       "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.1.tgz",
       "integrity": "sha512-uuPNLJkKN8NXAlZlQ6kmUF9qO+T6Kyd7oV4+/7yy8Jz6+MZNyhPq8EdLpdfnPVzUC8qSf1b4j1azKaGnFsjmsw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "acorn": "^8.5.0",
         "eslint-visitor-keys": "^3.0.0",
@@ -5381,7 +5389,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -5394,7 +5401,6 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
@@ -6284,6 +6290,7 @@
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
       "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^7.7.7"
       },
@@ -6405,6 +6412,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7208,6 +7216,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7362,6 +7371,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.4.tgz",
       "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -7538,6 +7548,7 @@
       "integrity": "sha512-QSD4I0fN6uZQfftryIXuqvqgBxTvJ3ZNkF6RWECd82YGAYAfhcppBLFXzXJHQAAhVFyYEuFTrq6h0hQqjB7jIQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.13",
         "@vitest/mocker": "4.0.13",
@@ -7625,6 +7636,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.24.tgz",
       "integrity": "sha512-uTHDOpVQTMjcGgrqFPSb8iO2m1DUvo+WbGqoXQz8Y1CeBYQ0FXf2z1gLRaBtHjlRz7zZUBHxjVB5VTLzYkvftg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.24",
         "@vue/compiler-sfc": "3.5.24",
@@ -7653,6 +7665,7 @@
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.2.0.tgz",
       "integrity": "sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0",
@@ -8001,7 +8014,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "devOptional": true,
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -8014,7 +8026,6 @@
       "resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-1.3.0.tgz",
       "integrity": "sha512-E/+VitOorXSLiAqtTd7Yqax0/pAS3xaYMP+AUUJGOK1OZG3rhcj9fcJOM5HJ2VrP1FrStVCWr1muTfQCdj4tAA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.0.0",
         "yaml": "^2.0.0"
@@ -8031,7 +8042,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },

--- a/src-tauri/src/config/models.rs
+++ b/src-tauri/src/config/models.rs
@@ -90,6 +90,7 @@ pub struct OutputSettings {
   pub download_dir: Option<String>,
   pub file_name_template: String,
   pub audio_file_name_template: String,
+  pub restrict_filenames: bool,
 }
 
 impl Default for OutputSettings {
@@ -108,6 +109,7 @@ impl Default for OutputSettings {
       download_dir: None,
       file_name_template: "%(title).200s-(%(height)sp%(fps).0d).%(ext)s".into(),
       audio_file_name_template: "%(title).200s-(%(abr)dk).%(ext)s".into(),
+      restrict_filenames: false,
     }
   }
 }

--- a/src-tauri/src/runners/ytdlp_args.rs
+++ b/src-tauri/src/runners/ytdlp_args.rs
@@ -167,6 +167,10 @@ pub fn build_output_args(
     args.push("--add-metadata".into());
   }
 
+  if output_settings.restrict_filenames {
+    args.push("--restrict-filenames".into());
+  }
+
   args
 }
 
@@ -434,5 +438,31 @@ mod tests {
     .collect();
 
     assert_eq!(args, expected);
+  }
+
+  #[test]
+  fn restrict_filenames_adds_flag_on_enable() {
+    let format_options = make_video_format_options(Some(720), Some(60));
+
+    let mut settings = OutputSettings::default();
+    settings.video.policy = TranscodePolicy::Never;
+    settings.restrict_filenames = true;
+
+    let args = build_output_args(&format_options, &settings);
+
+    assert!(args.contains(&"--restrict-filenames".to_string()));
+  }
+
+  #[test]
+  fn restrict_filenames_omits_flag_on_disable() {
+    let format_options = make_video_format_options(Some(720), Some(60));
+
+    let mut settings = OutputSettings::default();
+    settings.video.policy = TranscodePolicy::Never;
+    settings.restrict_filenames = false;
+
+    let args = build_output_args(&format_options, &settings);
+
+    assert!(!args.contains(&"--restrict-filenames".to_string()));
   }
 }

--- a/src/components/settings/FormatPresetSelector.vue
+++ b/src/components/settings/FormatPresetSelector.vue
@@ -28,11 +28,24 @@
         v-model="internalTemplate"
     />
 
-    <p v-if="example" class="font-semibold mb-2">
+    <div class="flex flex-col mb-4">
+      <label class="font-semibold mb-2" :for="`${idPrefix}-restrictFilenames`">
+        {{ restrictFilenamesLabel }}
+      </label>
+      <input
+          :id="`${idPrefix}-restrictFilenames`"
+          type="checkbox"
+          v-model="internalRestrictFilenames"
+          class="toggle toggle-primary"
+      />
+      <span class="label-text-alt opacity-70 mt-2">{{ restrictFilenamesHint }}</span>
+    </div>
+
+    <p v-if="displayExample" class="font-semibold mb-2">
       {{ exampleLabel }}
     </p>
-    <p v-if="example" class="text-[14px] mb-2">
-      {{ example }}
+    <p v-if="displayExample" class="text-[14px] mb-2">
+      {{ displayExample }}
     </p>
   </div>
 </template>
@@ -56,11 +69,15 @@ const props = defineProps<{
   presetLabel: string;
   formatLabel: string;
   exampleLabel: string;
+  restrictFilenames: boolean;
+  restrictFilenamesLabel: string;
+  restrictFilenamesHint: string;
 }>();
 
 const emit = defineEmits<{
   'update:modelValue': [string];
   'update:preset': [FormatPreset];
+  'update:restrictFilenames': [boolean];
 }>();
 
 const isCustom = computed(() => props.preset === FormatPreset.Custom);
@@ -96,6 +113,13 @@ const internalTemplate = computed<string>({
   },
 });
 
+const internalRestrictFilenames = computed<boolean>({
+  get: () => props.restrictFilenames,
+  set(val) {
+    emit('update:restrictFilenames', val);
+  },
+});
+
 const example = computed<string | undefined>(() => {
   if (isCustom.value) return undefined;
   return (
@@ -103,5 +127,14 @@ const example = computed<string | undefined>(() => {
     ?? props.modelValue
     ?? props.presets[0]?.example
   );
+});
+
+const displayExample = computed<string | undefined>(() => {
+  const base = example.value;
+  if (!base) return undefined;
+  if (props.restrictFilenames) {
+    return base.replace(/\s+/g, '_').replace(/&/g, '_and_');
+  }
+  return base;
 });
 </script>

--- a/src/components/settings/SettingsFilename.vue
+++ b/src/components/settings/SettingsFilename.vue
@@ -14,9 +14,12 @@
             :presets="videoFormatPresets"
             v-model="videoTemplate"
             v-model:preset="selectedVideoFormatPreset"
+            v-model:restrict-filenames="restrictFilenames"
             :preset-label="t('settings.filename.formatPreset.label')"
             :format-label="t('settings.filename.outputFormat.label')"
             :example-label="t('settings.filename.formatPreset.exampleLabel')"
+            :restrict-filenames-label="t('settings.filename.formatPreset.restrictFilenames.label')"
+            :restrict-filenames-hint="t('settings.filename.formatPreset.restrictFilenames.hint')"
         />
       </template>
 
@@ -26,9 +29,12 @@
             :presets="audioFormatPresets"
             v-model="audioTemplate"
             v-model:preset="selectedAudioFormatPreset"
+            v-model:restrict-filenames="restrictFilenames"
             :preset-label="t('settings.filename.formatPreset.label')"
             :format-label="t('settings.filename.outputFormat.label')"
             :example-label="t('settings.filename.formatPreset.exampleLabel')"
+            :restrict-filenames-label="t('settings.filename.formatPreset.restrictFilenames.label')"
+            :restrict-filenames-hint="t('settings.filename.formatPreset.restrictFilenames.hint')"
         />
       </template>
     </tabbed-settings-pane>
@@ -131,6 +137,13 @@ const audioTemplate = computed<string>({
   get: () => settings.value.output.audioFileNameTemplate ?? '',
   set(val) {
     settings.value.output.audioFileNameTemplate = val;
+  },
+});
+
+const restrictFilenames = computed<boolean>({
+  get: () => settings.value.output.restrictFilenames ?? false,
+  set(val) {
+    settings.value.output.restrictFilenames = val;
   },
 });
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -415,6 +415,10 @@
             "titleOnly": "My Audio.mp3",
             "titleQualityPlaylist": "03-My Audio-(320k).mp3"
           }
+        },
+        "restrictFilenames": {
+          "label": "Restrict filenames:",
+          "hint": "Replaces spaces with underscores and removes special characters like \"&\" from filenames."
         }
       },
       "outputFormat": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -415,6 +415,10 @@
             "titleOnly": "Mon audio.mp3",
             "titleQualityPlaylist": "03-Mon audio-(320k).mp3"
           }
+        },
+        "restrictFilenames": {
+          "label": "Restriction des noms de fichiers :",
+          "hint": "Remplace les espaces par des traits de soulignement et supprime les caractères spéciaux tels que \\«&\\» des noms de fichiers."
         }
       },
       "outputFormat": {

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -415,6 +415,10 @@
             "titleOnly": "Il mio audio.mp3",
             "titleQualityPlaylist": "03-Il mio audio-(320k).mp3"
           }
+        },
+        "restrictFilenames": {
+          "label": "Limitare i nomi dei file:",
+          "hint": "Sostituisce gli spazi con trattini bassi e rimuove i caratteri speciali come \"&\" dai nomi dei file."
         }
       },
       "outputFormat": {

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -415,6 +415,10 @@
             "titleOnly": "Mijn Audio.mp3",
             "titleQualityPlaylist": "03-Mijn Audio-(320k).mp3"
           }
+        },
+        "restrictFilenames": {
+          "label": "Beperk bestandsnamen:",
+          "hint": "Vervangt spaties door onderstrepingstekens en verwijdert speciale tekens zoals \"&\" uit bestandsnamen."
         }
       },
       "outputFormat": {

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -415,6 +415,10 @@
             "titleOnly": "Meu áudio.mp3",
             "titleQualityPlaylist": "03-Meu áudio-(320k).mp3"
           }
+        },
+        "restrictFilenames": {
+          "label": "Restringir nomes de arquivos:",
+          "hint": "Substitui espaços por sublinhados e remove caracteres especiais como \"&\" dos nomes dos arquivos."
         }
       },
       "outputFormat": {

--- a/src/tauri/types/config.ts
+++ b/src/tauri/types/config.ts
@@ -50,6 +50,7 @@ export interface OutputSettings {
   downloadDir: string | null;
   fileNameTemplate: string;
   audioFileNameTemplate: string;
+  restrictFilenames: boolean;
 }
 
 export interface PerformanceSettings {
@@ -122,6 +123,7 @@ export const defaultOutputSettings: OutputSettings = {
   downloadDir: null,
   fileNameTemplate: '%(title).200s-(%(height)sp%(fps).0d).%(ext)s',
   audioFileNameTemplate: '%(title).200s-(%(abr)dk).%(ext)s',
+  restrictFilenames: false,
 };
 
 export const defaultPerformanceSettings: PerformanceSettings = {


### PR DESCRIPTION
I thought the filename format option could be extended with `yt-dlp`'s `--restrict-filenames` flag so if a user chooses, in [`yt-dlp`'s own words](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#filesystem-options), this would: "Restrict filenames to only ASCII characters, and avoid "&" and spaces in filenames". A nice option for users who for example mostly navigate their file systems through a terminal.

<img width="523" height="471" alt="image" src="https://github.com/user-attachments/assets/30ce9d32-a2bb-4588-9916-21745fa98633" />
<img width="1364" height="887" alt="image" src="https://github.com/user-attachments/assets/d486bf61-d231-4693-9949-627a0e7728b7" />


I don't speak the other languages that have translation keys aside from English, but since the build fails if a new key is missing, I've provided machine translations for these using DeepL for the record. I can't speak for their accuracy and translators may want to rewrite them.

