### PR TITLE
fix: detect VideoRemux and VideoConverter destination paths

### DIFF
--- a/src-tauri/src/parsers/ytdlp_progress.rs
+++ b/src-tauri/src/parsers/ytdlp_progress.rs
@@ -66,7 +66,7 @@ impl YtdlpProgressParser {
         group_id: self.group_id.clone(),
         is_merged: true,
         destination: MediaDestinationPath {
-          confidence: 100,
+          confidence: 80,
           path: destination,
         },
       }));
@@ -75,14 +75,22 @@ impl YtdlpProgressParser {
   }
 
   fn try_destination(&self, line: &str) -> Option<ProgressEvent> {
-    let (prefix_part, rest) = line.split_once("] Destination:")?;
-    let prefix = prefix_part.trim_start_matches('[');
-    let confidence = match prefix {
-      "Merger" | "ExtractAudio" => 95,
-      "download" => 80,
-      _ => 70,
-    };
+    let (_, rest) = line.split_once("Destination:")?;
     let full_path = rest.trim().to_string();
+
+    let tag = line
+      .split(']')
+      .next()
+      .map(|s| s.trim_start_matches('['))
+      .unwrap_or("unknown");
+
+    let confidence = match tag {
+      "VideoConvertor" => 95,
+      "VideoRemuxer" => 90,
+      "Merger" | "ExtractAudio" => 70,
+      "download" => 60,
+      _ => 50,
+    };
 
     Some(ProgressEvent::Destination(MediaDestination {
       id: self.id.clone(),


### PR DESCRIPTION
When a video would get remuxed or converted, the earlier detected path would no longer match up. Causing the "open file" buttons to fail.

This fix makes sure the VideoRemux and VideoConverter destination log lines are properly detected with a higher confidence score so they are used before anything else.

Fixes #624.