### PR TITLE
fix: add missing documentation links in CookiesConfig

### DIFF
--- a/src/components/authentication/CookiesConfig.vue
+++ b/src/components/authentication/CookiesConfig.vue
@@ -15,7 +15,7 @@
     <span class="label mb-2 gap-1">
       <i18n-t keypath="auth.cookies.file.hint" scope="global">
         <template #link>
-          <a href="" class="link">
+          <a href="https://github.com/jely2002/youtube-dl-gui/wiki/Tutorial:-Private-videos-&-playlists" class="link" target="_blank" rel="noopener">
             {{ t('auth.cookies.file.hintLink') }}
           </a>
         </template>
@@ -41,7 +41,7 @@
     <span class="label mb-2 gap-1">
       <i18n-t keypath="auth.cookies.browser.hint" scope="global">
         <template #link>
-          <a href="" class="link">
+          <a href="https://github.com/jely2002/youtube-dl-gui/wiki/Cookie-extraction:-supported-browsers" class="link" target="_blank" rel="noopener">
             {{ t('auth.cookies.browser.hintLink') }}
           </a>
         </template>


### PR DESCRIPTION
Adds missing links to the cookies tutorial and list of supported browsers.

Fixes #627.