### PR TITLE
Add proxy toggle to settings and handle proxy errors

### DIFF
--- a/src-tauri/src/diagnostic_rules.json
+++ b/src-tauri/src/diagnostic_rules.json
@@ -244,6 +244,13 @@
       "patterns": [
         { "kind": "substr", "value": "Retrying fragment download" }
       ]
+    },
+    {
+      "code": "unableToConnectToProxy",
+      "appliesTo": "error",
+      "patterns": [
+        { "kind": "substr", "value": "Unable to connect to proxy" }
+      ]
     }
   ],
   "fallbackCode": "unknown"

--- a/src-tauri/src/runners/ytdlp_runner.rs
+++ b/src-tauri/src/runners/ytdlp_runner.rs
@@ -52,9 +52,12 @@ impl<'a> YtdlpRunner<'a> {
   }
 
   pub fn with_network_args(mut self) -> Self {
-    if let Some(ref proxy) = self.cfg.network.proxy {
-      self.args.push("--proxy".to_string());
-      self.args.push(proxy.clone());
+    let proxy_enabled = self.cfg.network.enable_proxy.is_some_and(|enabled| enabled);
+    if proxy_enabled {
+      if let Some(proxy) = self.cfg.network.proxy.as_ref() {
+        self.args.push("--proxy".to_string());
+        self.args.push(proxy.clone());
+      }
     }
 
     match self.cfg.network.impersonate.as_str() {

--- a/src-tauri/src/state/config.rs
+++ b/src-tauri/src/state/config.rs
@@ -16,6 +16,10 @@ impl JsonBackedState for Config {
   }
 
   fn before_initialized(app: &AppHandle<Wry>, value: &mut Self) {
+    if value.network.enable_proxy.is_none() {
+      value.network.enable_proxy =
+        Some(value.network.proxy.as_ref().is_some_and(|v| !v.is_empty()));
+    }
     if value.output.download_dir.is_none() {
       let download_path = app
         .path()

--- a/src-tauri/src/state/config_models.rs
+++ b/src-tauri/src/state/config_models.rs
@@ -38,6 +38,7 @@ impl Default for AuthSettings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct NetworkSettings {
+  pub enable_proxy: Option<bool>,
   pub proxy: Option<String>,
   pub impersonate: String,
 }
@@ -45,6 +46,7 @@ pub struct NetworkSettings {
 impl Default for NetworkSettings {
   fn default() -> Self {
     Self {
+      enable_proxy: None,
       proxy: None,
       impersonate: "none".into(),
     }

--- a/src/components/settings/SettingsNetwork.vue
+++ b/src/components/settings/SettingsNetwork.vue
@@ -3,6 +3,15 @@
       :legend="t('settings.network.legend')"
       :label="t('settings.network.legendLabel')"
   >
+    <label class="font-semibold mt-2" for="enableProxy">
+      {{ t('settings.network.enableProxy.label') }}
+    </label>
+    <input
+        id="enableProxy"
+        type="checkbox"
+        v-model="settings.network.enableProxy"
+        class="toggle toggle-primary"
+    />
     <label class="font-semibold mt-2" for="proxyUrl">
       {{ t('settings.network.proxy.label') }}
     </label>
@@ -10,6 +19,7 @@
         type="text"
         id="proxyUrl"
         class="input mb-2"
+        :disabled="settings.network.enableProxy !== true"
         v-model="settings.network.proxy"
         placeholder="socks5://user:pass@127.0.0.1:1080/"
     />

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -526,6 +526,9 @@
     "network": {
       "legend": "Netzwerk",
       "legendLabel": "Lege fest, wie die Anwendung eine Verbindung zum Internet herstellt.",
+      "enableProxy": {
+        "label": "Über Proxy verbinden:"
+      },
       "proxy": {
         "label": "Proxy-Konfiguration:"
       },
@@ -800,6 +803,10 @@
       "networkNameResolutionFailed": {
         "shortMessage": "Netzwerkfehler",
         "message": "Der Hostname konnte nicht aufgelöst werden. Prüfe deine Internetverbindung."
+      },
+      "unableToConnectToProxy": {
+        "shortMessage": "Proxy-Verbindung fehlgeschlagen",
+        "message": "Verbindung zum Proxy nicht möglich. Prüfe die Proxy-Einstellungen."
       },
       "playlistPrivateOrMissing": {
         "shortMessage": "Playlist nicht verfügbar",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -526,6 +526,9 @@
     "network": {
       "legend": "Network",
       "legendLabel": "Configure how the application connects to the internet.",
+      "enableProxy": {
+        "label": "Connect via proxy:"
+      },
       "proxy": {
         "label": "Proxy configuration:"
       },
@@ -800,6 +803,10 @@
       "networkNameResolutionFailed": {
         "shortMessage": "Network error",
         "message": "Couldn’t resolve the host name. Check your internet connection."
+      },
+      "unableToConnectToProxy": {
+        "shortMessage": "Proxy connection failed",
+        "message": "Unable to connect to the proxy. Check your proxy settings."
       },
       "playlistPrivateOrMissing": {
         "shortMessage": "Playlist unavailable",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -526,6 +526,9 @@
     "network": {
       "legend": "Red",
       "legendLabel": "Configura cómo se conecta la aplicación a internet.",
+      "enableProxy": {
+        "label": "Conectar vía proxy:"
+      },
       "proxy": {
         "label": "Configuración de proxy:"
       },
@@ -800,6 +803,10 @@
       "networkNameResolutionFailed": {
         "shortMessage": "Error de red",
         "message": "No se pudo resolver el nombre del host. Verifica tu conexión a internet."
+      },
+      "unableToConnectToProxy": {
+        "shortMessage": "Conexión al proxy fallida",
+        "message": "No se pudo conectar al proxy. Revisa la configuración del proxy."
       },
       "playlistPrivateOrMissing": {
         "shortMessage": "Lista no disponible",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -526,6 +526,9 @@
     "network": {
       "legend": "Réseau",
       "legendLabel": "Configurer comment l’application se connecte à Internet.",
+      "enableProxy": {
+        "label": "Se connecter via un proxy :"
+      },
       "proxy": {
         "label": "Configuration du proxy :"
       },
@@ -800,6 +803,10 @@
       "networkNameResolutionFailed": {
         "shortMessage": "Erreur réseau",
         "message": "Impossible de résoudre le nom d’hôte. Vérifiez votre connexion Internet."
+      },
+      "unableToConnectToProxy": {
+        "shortMessage": "Échec de connexion au proxy",
+        "message": "Impossible de se connecter au proxy. Vérifiez les paramètres du proxy."
       },
       "playlistPrivateOrMissing": {
         "shortMessage": "Playlist indisponible",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -526,6 +526,9 @@
     "network": {
       "legend": "Rete",
       "legendLabel": "Configura la modalità di connessione dell'applicazione ad internet.",
+      "enableProxy": {
+        "label": "Connetti tramite proxy:"
+      },
       "proxy": {
         "label": "Configurazione proxy:"
       },
@@ -800,6 +803,10 @@
       "networkNameResolutionFailed": {
         "shortMessage": "errore di rete",
         "message": "Impossibile risolvere il nome host. Controlla la connessione internet."
+      },
+      "unableToConnectToProxy": {
+        "shortMessage": "Connessione al proxy non riuscita",
+        "message": "Impossibile connettersi al proxy. Controlla le impostazioni del proxy."
       },
       "playlistPrivateOrMissing": {
         "shortMessage": "Playlist non disponibile",

--- a/src/locales/nb.json
+++ b/src/locales/nb.json
@@ -526,6 +526,9 @@
     "network": {
       "legend": "Nettverk",
       "legendLabel": "Konfigurer hvordan applikasjonen kobler til internett.",
+      "enableProxy": {
+        "label": "Koble til via proxy:"
+      },
       "proxy": {
         "label": "Proxy-konfigurasjon:"
       },
@@ -800,6 +803,10 @@
       "networkNameResolutionFailed": {
         "shortMessage": "Nettverksfeil",
         "message": "Kunne ikke løse vertsnavnet. Sjekk internettforbindelsen din."
+      },
+      "unableToConnectToProxy": {
+        "shortMessage": "Proxy-tilkobling mislyktes",
+        "message": "Kunne ikke koble til proxyen. Sjekk proxyinnstillingene."
       },
       "playlistPrivateOrMissing": {
         "shortMessage": "Spilleliste utilgjengelig",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -526,6 +526,9 @@
     "network": {
       "legend": "Netwerk",
       "legendLabel": "Instellen hoe de app verbinding maakt met internet.",
+      "enableProxy": {
+        "label": "Verbinden via proxy:"
+      },
       "proxy": {
         "label": "Proxyconfiguratie:"
       },
@@ -800,6 +803,10 @@
       "networkNameResolutionFailed": {
         "shortMessage": "Netwerkfout",
         "message": "De hostnaam kon niet worden opgelost. Controleer je internetverbinding."
+      },
+      "unableToConnectToProxy": {
+        "shortMessage": "Proxyverbinding mislukt",
+        "message": "Kan geen verbinding maken met de proxy. Controleer de proxy-instellingen."
       },
       "playlistPrivateOrMissing": {
         "shortMessage": "Playlist niet beschikbaar",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -526,6 +526,9 @@
     "network": {
       "legend": "Rede",
       "legendLabel": "Configure como o aplicativo se conecta à Internet.",
+      "enableProxy": {
+        "label": "Conectar via proxy:"
+      },
       "proxy": {
         "label": "Configuração de proxy:"
       },
@@ -800,6 +803,10 @@
       "networkNameResolutionFailed": {
         "shortMessage": "Erro de rede",
         "message": "Não foi possível resolver o nome do host. Verifique sua conexão com a Internet."
+      },
+      "unableToConnectToProxy": {
+        "shortMessage": "Falha na conexão com o proxy",
+        "message": "Não foi possível conectar ao proxy. Verifique as configurações do proxy."
       },
       "playlistPrivateOrMissing": {
         "shortMessage": "Playlist indisponível",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -526,6 +526,9 @@
     "network": {
       "legend": "Сеть",
       "legendLabel": "Настройте, как приложение подключается к интернету.",
+      "enableProxy": {
+        "label": "Подключаться через прокси:"
+      },
       "proxy": {
         "label": "Настройка прокси:"
       },
@@ -800,6 +803,10 @@
       "networkNameResolutionFailed": {
         "shortMessage": "Сетевая ошибка",
         "message": "Не удалось определить имя хоста. Проверьте подключение к интернету."
+      },
+      "unableToConnectToProxy": {
+        "shortMessage": "Не удалось подключиться к прокси",
+        "message": "Не удалось подключиться к прокси. Проверьте настройки прокси."
       },
       "playlistPrivateOrMissing": {
         "shortMessage": "Плейлист недоступен",

--- a/src/tauri/types/config.ts
+++ b/src/tauri/types/config.ts
@@ -17,6 +17,7 @@ export interface AuthSettings {
 }
 
 export interface NetworkSettings {
+  enableProxy: boolean | null;
   proxy: string | null;
   impersonate: string;
 }
@@ -138,6 +139,7 @@ export const defaultAuthSettings: AuthSettings = {
 };
 
 export const defaultNetworkSettings: NetworkSettings = {
+  enableProxy: false,
   proxy: null,
   impersonate: 'none',
 };


### PR DESCRIPTION
Adds a proxy toggle in the settings. Also adds error handling for proxy connection issues. In order to not nuke existing settings I've had to tweak the merge logic a bit.

Closes #648 
