### PR TITLE
feat: Add 'ovd://' deep link protocol support

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -911,6 +911,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,6 +1444,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -2320,6 +2349,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -3830,6 +3865,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-autostart",
  "tauri-plugin-clipboard-manager",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-keyring",
@@ -3896,6 +3932,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "ordered-stream"
@@ -4823,6 +4869,16 @@ dependencies = [
  "base64 0.21.7",
  "blake2b_simd",
  "constant_time_eq 0.3.1",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -6005,6 +6061,27 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444b091f24f2f6bdb4a305b54d3961f629c11861c685aceeea9a1972f89e43d5"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.17",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -7495,6 +7572,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -55,6 +55,7 @@ indexmap = { version = "2.12.1", features = ["serde"] }
 include_dir = "0.7.4"
 sys-locale = "0.3.2"
 notify-rust = "4.11.7"
+tauri-plugin-deep-link = "2"
 
 [profile.dev]
 incremental = true

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -33,6 +33,7 @@
     "dialog:default",
     "store:default",
     "updater:default",
-    "notification:default"
+    "notification:default",
+    "deep-link:default"
   ]
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -65,6 +65,13 @@
     }
   },
   "plugins": {
+    "deep-link": {
+      "desktop": {
+        "schemes": [
+          "ovd"
+        ]
+      }
+    },
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDNBRTI0NDIwNzRDQUIzRUMKUldUc3M4cDBJRVRpT21CaVE1VmRZQ3pLSGZKb2F3OGRkM2ZCYXEyYStUQ0UyNnJ0aDBKMXh3eU4K",
       "endpoints": [

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,20 +1,24 @@
 <template>
-  <router-view/>
-  <the-toaster/>
+  <router-view />
+  <the-toaster />
 </template>
 
 <script setup lang="ts">
+import { onMounted } from 'vue';
+import { listen } from '@tauri-apps/api/event';
 import TheToaster from './components/TheToaster.vue';
 import { useBinariesStore } from './stores/binaries';
 import { useRouter } from 'vue-router';
 import { useUpdaterStore } from './stores/updater';
 import { useStrongholdStore } from './stores/stronghold';
 import { useDragDrop } from './composables/useDragDrop.ts';
+import { useMediaStore } from './stores/media/media'; // Import the media store
 
 const router = useRouter();
 const binariesStore = useBinariesStore();
 const updaterStore = useUpdaterStore();
 const strongholdStore = useStrongholdStore();
+const mediaStore = useMediaStore(); // Initialize media store
 
 useDragDrop();
 
@@ -33,6 +37,27 @@ const checkUpdates = async () => {
   }
 };
 
+// --- NEW: Deep Link Listener ---
+onMounted(async () => {
+  await listen<string[]>('deep-link', (event) => {
+    const args = event.payload;
+    const url = args.find(arg => arg.startsWith('ovd://'));
+
+    if (url) {
+      // Clean and fix the URL
+      let cleanUrl = url.replace('ovd://', '').replace('https//', 'https://');
+      if (cleanUrl.startsWith('https') && !cleanUrl.includes('://')) {
+        cleanUrl = cleanUrl.replace('https', 'https://');
+      }
+
+      // Trigger the download
+      void mediaStore.dispatchMediaInfoFetch(cleanUrl);
+    }
+  });
+});
+// -------------------------------
+
+// --- Original Startup Logic ---
 try {
   void checkTools();
 } catch (e) {


### PR DESCRIPTION
This PR adds support for the custom `ovd://` protocol. This allows external applications (such as browser extensions) to send video URLs directly to Open Video Downloader.

Changes:
- src-tauri/tauri.conf.json: Registered the `ovd` scheme.
- src-tauri/src/lib.rs: Initialized `tauri_plugin_deep_link` and added cold-start argument parsing.
- src-tauri/capabilities/default.json: Added `deep-link:default` permission.
- src/App.vue: Added a frontend event listener to parse the URL and trigger the download queue.