### PR TITLE
feat: add native audio quality checker for downloaded audio

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1729,6 +1729,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3562,10 +3568,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -3858,11 +3882,13 @@ dependencies = [
  "rand 0.10.1",
  "regex",
  "reqwest 0.13.2",
+ "rustfft",
  "sentry",
  "serde",
  "serde_json",
  "sha2",
  "shlex",
+ "symphonia",
  "sys-locale",
  "tar",
  "tauri",
@@ -4426,6 +4452,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
 ]
 
 [[package]]
@@ -5017,6 +5052,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
 ]
 
 [[package]]
@@ -5817,6 +5866,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5944,6 +5999,155 @@ dependencies = [
  "base64 0.21.7",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "symphonia"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1758d6c853020a7244de03cc3e0185eaea3f58715122422dd3cc7452e6d4c16a"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-flac",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-isomp4",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee69ad01236a67260b82fd1ff9790dd75ead29f2f46af145e63b7e72273e0e03"
+dependencies = [
+ "log",
+ "symphonia-common",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350f1f2f2e19ad4dd315db94304d1eb361b29af070681f94e51b8fdaad769546"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1979c515a76371b186aad2feff5f23e21cbec775bf95de08bf1e3af92a2ad76"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-common",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50baee168f0e9dcf6ba7fc06e8b57eb62072a4490cc7cf13af77e72baae5d328"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45b07b4423cd8e0fc472575909a5554b12c2f58e3c190b38c24f042e732fd8de"
+dependencies = [
+ "log",
+ "symphonia-common",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-common"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8257891ffa7f05e02b58f4761e2abf7e5278c8744fd59e981559e050f86eef55"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ec293b5f288383b72a7bffcade6b2860b642cf66f28b3bd5967349a49938b1"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "lazy_static",
+ "log",
+ "num-complex",
+ "smallvec",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d179a01305b3505940135a9f0180d6ef4b487912748fe97554756f120fbd05e"
+dependencies = [
+ "log",
+ "symphonia-common",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-format-ogg"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05a67e02b1e4fca1a261ba4fe06910a9357489ad8c36aafdd2960e9c6559433"
+dependencies = [
+ "log",
+ "symphonia-common",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17424452a777666d3eaf09a5c651029b15b6a333812fcc5b5474f2a3f0cff3f0"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31acf5cd623398a6208e2225d18f4b20f761c55098a796a5247ad516a4a8681"
+dependencies = [
+ "lazy_static",
+ "log",
+ "regex-lite",
+ "smallvec",
+ "symphonia-core",
 ]
 
 [[package]]
@@ -7040,6 +7244,16 @@ dependencies = [
  "thread_local",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -59,6 +59,8 @@ include_dir = "0.7.4"
 sys-locale = "0.3.2"
 notify-rust = "4.12"
 shlex = "1.3.0"
+symphonia = { version = "0.6.0", default-features = false, features = ["mp3", "aac", "isomp4", "flac", "vorbis", "wav", "pcm", "ogg"] }
+rustfft = "6.4.1"
 
 [dev-dependencies]
 tauri = { version = "2.11.1", features = ["test"] }

--- a/src-tauri/src/audio_quality/decode.rs
+++ b/src-tauri/src/audio_quality/decode.rs
@@ -1,0 +1,130 @@
+use std::fmt;
+use std::fs::File;
+use std::path::Path;
+
+use symphonia::core::codecs::audio::AudioDecoderOptions;
+use symphonia::core::codecs::CodecParameters;
+use symphonia::core::errors::Error as SymphoniaError;
+use symphonia::core::formats::probe::Hint;
+use symphonia::core::formats::{FormatOptions, TrackType};
+use symphonia::core::io::{MediaSourceStream, MediaSourceStreamOptions};
+use symphonia::core::meta::MetadataOptions;
+
+pub struct DecodedAudio {
+  pub samples: Vec<f32>,
+  pub sample_rate: u32,
+}
+
+#[derive(Debug)]
+pub enum DecodeError {
+  Io(std::io::Error),
+  UnsupportedFormat,
+  NoAudioTrack,
+  DecodeFailed(String),
+}
+
+impl fmt::Display for DecodeError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::Io(e) => write!(f, "Failed to read audio file: {e}"),
+      Self::UnsupportedFormat => write!(f, "Unsupported or undecodable audio format"),
+      Self::NoAudioTrack => write!(f, "No audio track found in file"),
+      Self::DecodeFailed(e) => write!(f, "Failed to decode audio: {e}"),
+    }
+  }
+}
+
+impl std::error::Error for DecodeError {}
+
+impl From<std::io::Error> for DecodeError {
+  fn from(e: std::io::Error) -> Self {
+    Self::Io(e)
+  }
+}
+
+pub fn decode_to_mono_samples(path: &Path) -> Result<DecodedAudio, DecodeError> {
+  let file = File::open(path)?;
+
+  let mut hint = Hint::new();
+  if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+    hint.with_extension(ext);
+  }
+
+  let mss = MediaSourceStream::new(Box::new(file), MediaSourceStreamOptions::default());
+
+  let mut format = symphonia::default::get_probe()
+    .probe(
+      &hint,
+      mss,
+      FormatOptions::default(),
+      MetadataOptions::default(),
+    )
+    .map_err(|_| DecodeError::UnsupportedFormat)?;
+
+  let track = format
+    .default_track(TrackType::Audio)
+    .ok_or(DecodeError::NoAudioTrack)?;
+  let track_id = track.id;
+
+  let audio_params = match track.codec_params.clone() {
+    Some(CodecParameters::Audio(params)) => params,
+    _ => return Err(DecodeError::NoAudioTrack),
+  };
+
+  let mut decoder = symphonia::default::get_codecs()
+    .make_audio_decoder(&audio_params, &AudioDecoderOptions::default())
+    .map_err(|_| DecodeError::UnsupportedFormat)?;
+
+  let mut sample_rate = audio_params.sample_rate.unwrap_or(0);
+  let mut mono_samples: Vec<f32> = Vec::new();
+  let mut interleaved: Vec<f32> = Vec::new();
+
+  loop {
+    let packet = match format.next_packet() {
+      Ok(Some(packet)) => packet,
+      Ok(None) => break,
+      Err(SymphoniaError::IoError(ref io_err))
+        if io_err.kind() == std::io::ErrorKind::UnexpectedEof =>
+      {
+        break;
+      }
+      Err(e) => return Err(DecodeError::DecodeFailed(e.to_string())),
+    };
+
+    if packet.track_id != track_id {
+      continue;
+    }
+
+    let decoded = match decoder.decode(&packet) {
+      Ok(decoded) => decoded,
+      Err(SymphoniaError::DecodeError(_)) => continue,
+      Err(e) => return Err(DecodeError::DecodeFailed(e.to_string())),
+    };
+
+    let spec = decoded.spec().clone();
+    if sample_rate == 0 {
+      sample_rate = spec.rate();
+    }
+    let channels = spec.channels().count().max(1);
+
+    interleaved.clear();
+    decoded.copy_to_vec_interleaved(&mut interleaved);
+
+    mono_samples.reserve(interleaved.len() / channels);
+    for frame in interleaved.chunks_exact(channels) {
+      let sum: f32 = frame.iter().sum();
+      mono_samples.push(sum / channels as f32);
+    }
+  }
+
+  if mono_samples.is_empty() || sample_rate == 0 {
+    return Err(DecodeError::DecodeFailed(
+      "no decodable audio samples found".to_string(),
+    ));
+  }
+
+  Ok(DecodedAudio {
+    samples: mono_samples,
+    sample_rate,
+  })
+}

--- a/src-tauri/src/audio_quality/metrics.rs
+++ b/src-tauri/src/audio_quality/metrics.rs
@@ -1,0 +1,247 @@
+use rustfft::num_complex::Complex;
+use rustfft::FftPlanner;
+
+const CLIPPING_THRESHOLD: f32 = 0.999;
+const CLIPPING_RATIO: f64 = 0.001;
+
+const FFT_SIZE: usize = 2048;
+const HOP_SIZE: usize = 1024;
+const FREQUENCY_ENERGY_RATIO: f64 = 0.001;
+
+const DYNAMIC_RANGE_WINDOW: usize = 2048;
+const RMS_EPSILON: f64 = 1e-10;
+
+const NOISE_FLOOR_WINDOW_SECS: f64 = 0.5;
+
+pub fn detect_clipping(samples: &[f32]) -> bool {
+  if samples.is_empty() {
+    return false;
+  }
+  let clipped = samples
+    .iter()
+    .filter(|s| s.abs() >= CLIPPING_THRESHOLD)
+    .count();
+  (clipped as f64 / samples.len() as f64) > CLIPPING_RATIO
+}
+
+pub fn estimate_max_frequency(samples: &[f32], sample_rate: u32) -> f32 {
+  if sample_rate == 0 || samples.len() < FFT_SIZE {
+    return 0.0;
+  }
+
+  let mut planner = FftPlanner::<f32>::new();
+  let fft = planner.plan_fft_forward(FFT_SIZE);
+
+  let window: Vec<f32> = (0..FFT_SIZE)
+    .map(|i| 0.5 - 0.5 * (2.0 * std::f32::consts::PI * i as f32 / (FFT_SIZE - 1) as f32).cos())
+    .collect();
+
+  let num_bins = FFT_SIZE / 2;
+  let mut energy = vec![0f64; num_bins];
+
+  let mut pos = 0;
+  while pos + FFT_SIZE <= samples.len() {
+    let mut buffer: Vec<Complex<f32>> = samples[pos..pos + FFT_SIZE]
+      .iter()
+      .zip(window.iter())
+      .map(|(s, w)| Complex::new(s * w, 0.0))
+      .collect();
+
+    fft.process(&mut buffer);
+
+    for (bin, value) in buffer.iter().take(num_bins).enumerate() {
+      energy[bin] += f64::from(value.norm_sqr());
+    }
+
+    pos += HOP_SIZE;
+  }
+
+  let max_energy = energy.iter().cloned().fold(0.0, f64::max);
+  if max_energy <= 0.0 {
+    return 0.0;
+  }
+
+  let threshold = max_energy * FREQUENCY_ENERGY_RATIO;
+  let highest_bin = energy
+    .iter()
+    .enumerate()
+    .rev()
+    .find(|(_, e)| **e > threshold)
+    .map_or(0, |(bin, _)| bin);
+
+  highest_bin as f32 * sample_rate as f32 / FFT_SIZE as f32
+}
+
+pub fn estimate_dynamic_range_db(samples: &[f32]) -> f32 {
+  if samples.is_empty() {
+    return 0.0;
+  }
+
+  let window = DYNAMIC_RANGE_WINDOW.min(samples.len()).max(1);
+  let mut rms_values: Vec<f64> = Vec::new();
+
+  let mut pos = 0;
+  while pos < samples.len() {
+    let end = (pos + window).min(samples.len());
+    let frame = &samples[pos..end];
+    let sum_sq: f64 = frame.iter().map(|s| f64::from(*s) * f64::from(*s)).sum();
+    let rms = (sum_sq / frame.len() as f64).sqrt();
+    if rms > 0.0 {
+      rms_values.push(rms);
+    }
+    pos += window;
+  }
+
+  if rms_values.is_empty() {
+    return 0.0;
+  }
+
+  let max_rms = rms_values.iter().cloned().fold(0.0, f64::max);
+  let min_rms = rms_values.iter().cloned().fold(f64::MAX, f64::min);
+
+  (20.0 * (max_rms / (min_rms + RMS_EPSILON)).log10()) as f32
+}
+
+pub fn estimate_noise_floor_rms(samples: &[f32], sample_rate: u32) -> f32 {
+  if samples.is_empty() || sample_rate == 0 {
+    return 0.0;
+  }
+
+  let window = ((f64::from(sample_rate)) * NOISE_FLOOR_WINDOW_SECS) as usize;
+  let window = window.min(samples.len()).max(1);
+  let frame = &samples[..window];
+
+  let sum_sq: f64 = frame.iter().map(|s| f64::from(*s) * f64::from(*s)).sum();
+  ((sum_sq / frame.len() as f64).sqrt()) as f32
+}
+
+pub fn score_and_issues(
+  clipping_detected: bool,
+  max_frequency_hz: f32,
+  dynamic_range_db: f32,
+  noise_floor_rms: f32,
+) -> (u8, Vec<String>) {
+  let mut score: i32 = 100;
+  let mut issues = Vec::new();
+
+  if clipping_detected {
+    score -= 40;
+    issues.push("Clipping detected".to_string());
+  }
+
+  if max_frequency_hz < 16_000.0 {
+    score -= 50;
+    issues.push(format!(
+      "Severe frequency cutoff at {max_frequency_hz:.0} Hz (likely heavily transcoded)"
+    ));
+  } else if max_frequency_hz < 19_000.0 {
+    score -= 20;
+    issues.push(format!(
+      "Frequency cutoff at {max_frequency_hz:.0} Hz (possible lossy transcode)"
+    ));
+  }
+
+  if dynamic_range_db < 6.0 {
+    score -= 25;
+    issues.push(format!("Very low dynamic range ({dynamic_range_db:.1} dB)"));
+  } else if dynamic_range_db < 12.0 {
+    score -= 10;
+    issues.push(format!("Low dynamic range ({dynamic_range_db:.1} dB)"));
+  }
+
+  if noise_floor_rms > 0.01 {
+    score -= 20;
+    issues.push(format!("High noise floor ({noise_floor_rms:.4} RMS)"));
+  }
+
+  (score.clamp(0, 100) as u8, issues)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn sine_wave(freq: f32, sample_rate: u32, duration_secs: f32, amplitude: f32) -> Vec<f32> {
+    let num_samples = (sample_rate as f32 * duration_secs) as usize;
+    (0..num_samples)
+      .map(|i| {
+        amplitude * (2.0 * std::f32::consts::PI * freq * i as f32 / sample_rate as f32).sin()
+      })
+      .collect()
+  }
+
+  #[test]
+  fn detects_clipping_in_heavily_clipped_signal() {
+    let mut samples = sine_wave(440.0, 44_100, 0.5, 1.5);
+    for s in &mut samples {
+      *s = s.clamp(-1.0, 1.0);
+    }
+    assert!(detect_clipping(&samples));
+  }
+
+  #[test]
+  fn does_not_detect_clipping_in_clean_signal() {
+    let samples = sine_wave(440.0, 44_100, 0.5, 0.5);
+    assert!(!detect_clipping(&samples));
+  }
+
+  #[test]
+  fn empty_signal_has_no_clipping() {
+    assert!(!detect_clipping(&[]));
+  }
+
+  #[test]
+  fn estimates_max_frequency_near_signal_frequency() {
+    let sample_rate = 44_100;
+    let samples = sine_wave(5_000.0, sample_rate, 1.0, 0.8);
+    let max_freq = estimate_max_frequency(&samples, sample_rate);
+    assert!(
+      (max_freq - 5_000.0).abs() < 200.0,
+      "expected ~5000 Hz, got {max_freq}"
+    );
+  }
+
+  #[test]
+  fn detects_low_max_frequency_for_low_passed_signal() {
+    let sample_rate = 44_100;
+    let samples = sine_wave(2_000.0, sample_rate, 1.0, 0.8);
+    let max_freq = estimate_max_frequency(&samples, sample_rate);
+    assert!(max_freq < 16_000.0);
+  }
+
+  #[test]
+  fn dynamic_range_is_low_for_constant_amplitude_signal() {
+    let samples = sine_wave(440.0, 44_100, 1.0, 0.5);
+    let dr = estimate_dynamic_range_db(&samples);
+    assert!(dr < 6.0, "expected low dynamic range, got {dr}");
+  }
+
+  #[test]
+  fn dynamic_range_is_higher_when_signal_has_quiet_and_loud_sections() {
+    let mut samples = sine_wave(440.0, 44_100, 0.5, 0.01);
+    samples.extend(sine_wave(440.0, 44_100, 0.5, 0.9));
+    let dr = estimate_dynamic_range_db(&samples);
+    assert!(dr > 12.0, "expected high dynamic range, got {dr}");
+  }
+
+  #[test]
+  fn noise_floor_reflects_quiet_start_amplitude() {
+    let samples = sine_wave(440.0, 44_100, 1.0, 0.02);
+    let noise_floor = estimate_noise_floor_rms(&samples, 44_100);
+    assert!(noise_floor > 0.0 && noise_floor < 0.02);
+  }
+
+  #[test]
+  fn perfect_signal_scores_one_hundred_and_passes() {
+    let (score, issues) = score_and_issues(false, 20_000.0, 20.0, 0.0001);
+    assert_eq!(score, 100);
+    assert!(issues.is_empty());
+  }
+
+  #[test]
+  fn clipped_low_quality_signal_fails() {
+    let (score, issues) = score_and_issues(true, 10_000.0, 4.0, 0.02);
+    assert!(score < 60);
+    assert_eq!(issues.len(), 4);
+  }
+}

--- a/src-tauri/src/audio_quality/mod.rs
+++ b/src-tauri/src/audio_quality/mod.rs
@@ -1,0 +1,46 @@
+mod decode;
+mod metrics;
+
+use serde::Serialize;
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioQualityResult {
+  pub score: u8,
+  pub passed: bool,
+  pub sample_rate: u32,
+  pub max_frequency_hz: f32,
+  pub dynamic_range_db: f32,
+  pub noise_floor_rms: f32,
+  pub clipping_detected: bool,
+  pub issues: Vec<String>,
+}
+
+pub fn analyze_audio_file(path: &Path) -> Result<AudioQualityResult, String> {
+  let decoded = decode::decode_to_mono_samples(path).map_err(|e| e.to_string())?;
+
+  let clipping_detected = metrics::detect_clipping(&decoded.samples);
+  let max_frequency_hz = metrics::estimate_max_frequency(&decoded.samples, decoded.sample_rate);
+  let dynamic_range_db = metrics::estimate_dynamic_range_db(&decoded.samples);
+  let noise_floor_rms = metrics::estimate_noise_floor_rms(&decoded.samples, decoded.sample_rate);
+
+  let (score, issues) = metrics::score_and_issues(
+    clipping_detected,
+    max_frequency_hz,
+    dynamic_range_db,
+    noise_floor_rms,
+  );
+  let passed = score >= 60 && !clipping_detected;
+
+  Ok(AudioQualityResult {
+    score,
+    passed,
+    sample_rate: decoded.sample_rate,
+    max_frequency_hz,
+    dynamic_range_db,
+    noise_floor_rms,
+    clipping_detected,
+    issues,
+  })
+}

--- a/src-tauri/src/commands/media/media_check_audio_quality.rs
+++ b/src-tauri/src/commands/media/media_check_audio_quality.rs
@@ -1,0 +1,9 @@
+use crate::audio_quality::{analyze_audio_file, AudioQualityResult};
+use std::path::PathBuf;
+
+#[tauri::command]
+pub async fn media_check_audio_quality(path: String) -> Result<AudioQualityResult, String> {
+  tauri::async_runtime::spawn_blocking(move || analyze_audio_file(&PathBuf::from(path)))
+    .await
+    .map_err(|e| e.to_string())?
+}

--- a/src-tauri/src/commands/media/mod.rs
+++ b/src-tauri/src/commands/media/mod.rs
@@ -1,7 +1,9 @@
+pub mod media_check_audio_quality;
 pub mod media_download;
 pub mod media_info;
 pub mod media_size;
 
+pub use media_check_audio_quality::*;
 pub use media_download::*;
 pub use media_info::*;
 pub use media_size::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod audio_quality;
 mod binaries;
 mod commands;
 mod i18n;
@@ -165,6 +166,7 @@ pub fn run() {
       media_size,
       media_info,
       media_download,
+      media_check_audio_quality,
       group_cancel,
       logging_subscribe,
       logging_unsubscribe,

--- a/src/components/media-card/steps/MediaDoneStep.vue
+++ b/src/components/media-card/steps/MediaDoneStep.vue
@@ -27,6 +27,31 @@
           {{ group.isCombined ? t('media.steps.done.openFirst') : t('media.steps.done.open') }}
         </button>
       </div>
+      <button
+          v-if="isAudioGroup"
+          :disabled="!groupDestination || audioQualityStore.isLoading(group.id)"
+          @click="checkAudioQuality"
+          class="btn btn-subtle"
+      >
+        <template v-if="audioQualityStore.isLoading(group.id)">
+          <span class="sr-only">{{ t('common.loading') }}</span>
+          <span class="loading loading-spinner loading-sm"></span>
+        </template>
+        <template v-else>
+          {{ t('media.steps.done.audioQuality.check') }}
+        </template>
+      </button>
+    </div>
+    <div v-if="isAudioGroup && (qualityResult || qualityError)" class="w-full flex flex-col gap-1">
+      <span v-if="qualityResult" class="badge badge-soft w-fit" :class="qualityBadgeClass">
+        {{ t('media.steps.done.audioQuality.score', { score: qualityResult.score }) }}
+      </span>
+      <ul v-if="qualityResult?.issues.length" class="text-sm list-disc list-inside opacity-70">
+        <li v-for="issue in qualityResult.issues" :key="issue">{{ issue }}</li>
+      </ul>
+      <span v-else-if="qualityError" class="badge badge-soft badge-error w-fit">
+        {{ t('media.steps.done.audioQuality.error') }}
+      </span>
     </div>
   </div>
 </template>
@@ -37,12 +62,17 @@ import { computed, PropType } from 'vue';
 import BaseProgress from '../../base/BaseProgress.vue';
 import { useOpener } from '../../../composables/useOpener';
 import { useMediaDestinationStore } from '../../../stores/media/destination';
+import { useMediaOptionsStore } from '../../../stores/media/options';
+import { useMediaAudioQualityStore } from '../../../stores/media/audioQuality';
 import { Group } from '../../../tauri/types/group';
+import { TrackType } from '../../../tauri/types/media';
 import { useI18n } from 'vue-i18n';
 
 const { t } = useI18n();
 const { openPath, revealPath } = useOpener();
 const destinationStore = useMediaDestinationStore();
+const optionsStore = useMediaOptionsStore();
+const audioQualityStore = useMediaAudioQualityStore();
 
 const { group } = defineProps({
   group: {
@@ -55,6 +85,24 @@ const groupDestination = computed(() => {
   const destination = destinationStore.getPrimaryDestination(group.id);
   return destination?.path;
 });
+
+const isAudioGroup = computed(() => optionsStore.getOptions(group.id)?.trackType === TrackType.audio);
+
+const qualityResult = computed(() => audioQualityStore.getResult(group.id));
+const qualityError = computed(() => audioQualityStore.getError(group.id));
+
+const qualityBadgeClass = computed(() => {
+  const score = qualityResult.value?.score ?? 0;
+  if (score >= 80) return 'badge-success';
+  if (score >= 60) return 'badge-warning';
+  return 'badge-error';
+});
+
+const checkAudioQuality = async () => {
+  const destination = groupDestination.value;
+  if (!destination) return;
+  await audioQualityStore.checkQuality(group.id, destination);
+};
 
 const openFile = async () => {
   const destination = groupDestination.value;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -312,7 +312,12 @@
         "showFolder": "Show in folder",
         "open": "Open file",
         "openFirst": "Open first file",
-        "undeterminedLocation": "Download location could not be determined for this item."
+        "undeterminedLocation": "Download location could not be determined for this item.",
+        "audioQuality": {
+          "check": "Check audio quality",
+          "score": "Quality score: {score}/100",
+          "error": "Could not analyze audio quality"
+        }
       },
       "error": {
         "errorPrefix": "Error - {message}",

--- a/src/stores/media/audioQuality.ts
+++ b/src/stores/media/audioQuality.ts
@@ -1,0 +1,34 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { invoke } from '@tauri-apps/api/core';
+import { AudioQualityResult } from '../../tauri/types/media';
+
+export const useMediaAudioQualityStore = defineStore('media-audio-quality', () => {
+  const results = ref<Record<string, AudioQualityResult>>({});
+  const errors = ref<Record<string, string>>({});
+  const loading = ref<Record<string, boolean>>({});
+
+  const getResult = (groupId: string): AudioQualityResult | undefined => results.value[groupId];
+  const getError = (groupId: string): string | undefined => errors.value[groupId];
+  const isLoading = (groupId: string): boolean => loading.value[groupId] ?? false;
+
+  async function checkQuality(groupId: string, path: string): Promise<void> {
+    loading.value[groupId] = true;
+    delete errors.value[groupId];
+    try {
+      results.value[groupId] = await invoke<AudioQualityResult>('media_check_audio_quality', { path });
+    } catch (e) {
+      errors.value[groupId] = String(e);
+    } finally {
+      loading.value[groupId] = false;
+    }
+  }
+
+  const removeResult = (groupId: string) => {
+    delete results.value[groupId];
+    delete errors.value[groupId];
+    delete loading.value[groupId];
+  };
+
+  return { results, errors, loading, getResult, getError, isLoading, checkQuality, removeResult };
+});

--- a/src/stores/media/media.ts
+++ b/src/stores/media/media.ts
@@ -9,6 +9,7 @@ import { useMediaOptionsStore } from './options';
 import { DownloadOptions, MediaAddPayload, MediaItem, TrackType } from '../../tauri/types/media';
 import { useMediaSizeStore } from './size.ts';
 import { useMediaDiagnosticsStore } from './diagnostics.ts';
+import { useMediaAudioQualityStore } from './audioQuality.ts';
 import { useSettingsStore } from '../settings.ts';
 import { Group } from '../../tauri/types/group.ts';
 import { notify, notifyGroup } from '../../tauri/notifications';
@@ -22,6 +23,7 @@ export const useMediaStore = defineStore('media', () => {
   const optionsStore = useMediaOptionsStore();
   const sizeStore = useMediaSizeStore();
   const diagnosticsStore = useMediaDiagnosticsStore();
+  const audioQualityStore = useMediaAudioQualityStore();
   const settingsStore = useSettingsStore();
 
   function finalizePlaylistGroup(group: Group) {
@@ -249,6 +251,7 @@ export const useMediaStore = defineStore('media', () => {
     diagnosticsStore.removeDiagnostics(group.id);
     destinationStore.deleteDestinations(group.id);
     optionsStore.removeOptions(group.id);
+    audioQualityStore.removeResult(group.id);
     groupStore.cancelGroup(group.id);
     groupStore.deleteGroup(group.id);
   }

--- a/src/tauri/types/media.ts
+++ b/src/tauri/types/media.ts
@@ -164,6 +164,17 @@ export type SubtitleInventory = {
   autoLanguages: string[];
 };
 
+export type AudioQualityResult = {
+  score: number;
+  passed: boolean;
+  sampleRate: number;
+  maxFrequencyHz: number;
+  dynamicRangeDb: number;
+  noiseFloorRms: number;
+  clippingDetected: boolean;
+  issues: string[];
+};
+
 export interface MediaAddPayload {
   groupId: string;
   total: number;


### PR DESCRIPTION
Adds a post-download audio analysis step using symphonia for decoding and rustfft for spectral analysis, entirely in Rust with no Python or FFmpeg dependency. Detects clipping, estimates the effective frequency cutoff (to flag lossy transcodes), dynamic range, and noise floor, then combines them into a 0-100 quality score with pass/fail and human readable issues.

Exposed as the media_check_audio_quality Tauri command, with a Pinia store and a "Check audio quality" button/badge on the done step for audio-only download groups.