### PR TITLE
feat(i18n): add Korean (ko) translation support

### DIFF
--- a/src-tauri/locales/ko.json
+++ b/src-tauri/locales/ko.json
@@ -1,0 +1,51 @@
+{
+  "tray": {
+    "quit": "종료",
+    "showOrHide": "창 표시/숨기기",
+    "addToQueue": "클립보드에서 추가",
+    "addAndDownload": "클립보드에서 추가 및 다운로드",
+    "downloadQueue": "대기열 다운로드",
+    "shortcuts": {
+      "ctrlShiftV": "Ctrl + Shift + V",
+      "ctrlShiftD": "Ctrl + Shift + D",
+      "ctrlShiftEnter": "Ctrl + Shift + Enter",
+      "altShiftV": "Alt + Shift + V",
+      "altShiftD": "Alt + Shift + D",
+      "altShiftEnter": "Alt + Shift + Enter"
+    }
+  },
+  "notifications": {
+    "queueAdded": {
+      "title": "대기열에 추가됨",
+      "body": "{title}"
+    },
+    "queueDownloading": {
+      "title": "대기열 다운로드 중",
+      "body": "{n}개 항목 다운로드 중 | {n}개 항목 다운로드 중"
+    },
+    "queueFinished": {
+      "title": "대기열 완료",
+      "body": "{n}개 항목 다운로드 완료 | {n}개 항목 다운로드 완료"
+    },
+    "videoFinished": {
+      "title": "다운로드 완료",
+      "body": "{title}"
+    },
+    "playlistFinished": {
+      "title": "재생목록 완료",
+      "body": "{title}"
+    },
+    "videoReady": {
+      "title": "다운로드 준비 완료",
+      "body": "{title}"
+    },
+    "playlistReady": {
+      "title": "재생목록 다운로드 준비 완료",
+      "body": "{title} | {title} ({n}개 항목) | {title} ({n}개 항목)"
+    },
+    "downloadFailed": {
+      "title": "다운로드 실패",
+      "body": "{title}\n{message}"
+    }
+  }
+}

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1,0 +1,1173 @@
+{
+  "common": {
+    "download": "다운로드",
+    "save": "저장",
+    "later": "나중에",
+    "load": "불러오기",
+    "install": "설치",
+    "percentage": "{percent}%",
+    "add": "추가",
+    "back": "뒤로",
+    "continue": "계속",
+    "retry": "재시도",
+    "enable": "활성화",
+    "pleaseWait": "잠시만 기다려 주세요…",
+    "loading": "불러오는 중",
+    "emptySearch": "결과를 찾을 수 없습니다.",
+    "parenthesis": "({content})",
+    "divide": "{left} / {right}",
+    "video": "동영상",
+    "unknown": "알 수 없음",
+    "confirm": "확인",
+    "best": "최고 품질",
+    "resume": "재개",
+    "urlImport": {
+      "added": "링크가 대기열에 추가되었습니다. | 링크 {n}개가 대기열에 추가되었습니다.",
+      "partial": "{added}개의 링크를 대기열에 추가했습니다. 유효하지 않은 항목 {skipped}개는 건너뛰었습니다.",
+      "noneFound": "입력 내용이나 파일에서 유효한 링크를 찾을 수 없습니다.",
+      "readError": "해당 파일을 읽을 수 없습니다."
+    }
+  },
+  "layout": {
+    "header": {
+      "placeholder": "대기열에 추가할 동영상/재생목록 링크를 입력하세요",
+      "watchClipboardPlaceholder": "클립보드 감시 중: 복사한 링크가 자동으로 대기열에 추가됩니다",
+      "actions": {
+        "more": "추가 작업 더보기",
+        "watchClipboardStart": "클립보드 감시",
+        "watchClipboardStop": "클립보드 감시 중지",
+        "importFile": "링크 가져오기",
+        "inputFilters": "필터"
+      },
+      "nav": {
+        "inputFilters": "필터",
+        "settings": "앱 설정"
+      }
+    },
+    "footer": {
+      "progress": {
+        "downloading": "대기열 다운로드 중 - {total}개 중 {done}개 완료.",
+        "completed": "다운로드 완료 – {n}개 항목을 다운로드했습니다. | 다운로드 완료 – {n}개 항목을 다운로드했습니다.",
+        "ready": "다운로드 준비 완료! {n}개 항목이 대기열에 있습니다. | 다운로드 준비 완료! {n}개 항목이 대기열에 있습니다."
+      },
+      "nav": {
+        "downloadLocation": "저장 위치",
+        "login": {
+          "screenReader": {
+            "on": "로그인 정보 편집 (현재 로그인됨)",
+            "off": "로그인 정보 편집 (현재 로그인되지 않음)"
+          },
+          "tooltip": {
+            "on": "로그인 정보 편집",
+            "off": "로그인"
+          }
+        },
+        "subtitles": {
+          "screenReader": {
+            "on": "자막 편집 (현재 사용함)",
+            "off": "자막 편집 (현재 사용 안 함)"
+          },
+          "tooltip": "자막"
+        }
+      },
+      "format": {
+        "trackSelect": {
+          "screenReader": "모든 동영상의 트랙 선택"
+        },
+        "formatSelect": {
+          "noFormats": "형식 없음",
+          "placeholder": "형식 선택",
+          "screenReader": "모든 동영상의 형식 선택"
+        }
+      },
+      "queue": {
+        "empty": "대기열 비우기",
+        "resume": "전체 재개",
+        "pause": "전체 일시정지",
+        "clearSuccessful": "완료된 항목 지우기",
+        "clearErrored": "오류 항목 지우기",
+        "clearPending": "대기 중인 항목 지우기",
+        "cancelDownloading": "다운로드 취소",
+        "more": "대기열 작업 더보기"
+      }
+    }
+  },
+  "auth": {
+    "title": "인증",
+    "cookies": {
+      "legend": "쿠키",
+      "legendBadge": "권장",
+      "legendLabel": "쿠키 파일 또는 브라우저에서 가져온 로그인 세션을 사용합니다.",
+      "file": {
+        "label": "cookies.txt 파일에서 쿠키 불러오기",
+        "hint": "쿠키를 파일로 내보내려면 {link}",
+        "hintLink": "가이드를 참고하세요."
+      },
+      "browser": {
+        "label": "브라우저에서 자동으로 쿠키 불러오기:",
+        "placeholder": "브라우저에서 쿠키를 불러오지 않음",
+        "hint": "일부 브라우저는 쿠키 불러오기를 지원하지 않을 수 있습니다. {link}",
+        "hintLink": "호환되는 브라우저 목록을 참고하세요."
+      }
+    },
+    "credentials": {
+      "title": "고급 방법",
+      "description": "기본 인증, 베어러 토큰, 헤더, 동영상 비밀번호 등의 방법을 사용합니다.",
+      "labels": {
+        "username": "사용자 이름",
+        "password": "비밀번호",
+        "token": "토큰",
+        "headers": "헤더"
+      },
+      "basicAuth": {
+        "legend": "기본 인증",
+        "legendLabel": "간단한 인증을 사용하는 사이트에 사용됩니다."
+      },
+      "videoPassword": {
+        "legend": "동영상 비밀번호",
+        "legendLabel": "보호된 동영상에 접근하기 위한 비밀번호를 입력하세요."
+      },
+      "bearerToken": {
+        "legend": "베어러 토큰",
+        "legendLabel": "비공개 리소스에 접근하기 위한 베어러 토큰을 입력하세요."
+      },
+      "customHeaders": {
+        "legend": "사용자 지정 헤더",
+        "legendBadge": "고급",
+        "legendLabel": "한 줄에 하나씩: FIELD:VALUE",
+        "placeholder": "X-Api-Key:…"
+      }
+    },
+    "init": {
+      "title": "보안 저장소가 활성화되지 않음",
+      "description": "고급 인증 방법을 사용하려면 보안 저장소를 활성화해야 합니다.",
+      "hint": "보안 저장소는 시스템의 키링을 사용하며, 비밀번호가 필요할 수 있습니다.",
+      "error": {
+        "title": "보안 저장소를 활성화할 수 없음",
+        "description": "보안 저장소를 활성화하는 중 오류가 발생했습니다. 다시 시도해 주세요.",
+        "hint": "오류: {error}",
+        "unknown": "알 수 없는 오류"
+      },
+      "toasts": {
+        "error": "보안 저장소를 초기화할 수 없습니다: {error}"
+      }
+    },
+    "toasts": {
+      "error": "인증 설정을 저장할 수 없습니다. {error}",
+      "saved": "인증 설정이 저장되었습니다!"
+    }
+  },
+  "media": {
+    "view": {
+      "tabs": {
+        "metadata": "메타데이터",
+        "logs": "로그"
+      },
+      "thumbnailAlt": "{title}의 썸네일",
+      "metadata": {
+        "uploader": "업로더:",
+        "extractor": "추출기:",
+        "link": "링크:",
+        "chapters": "챕터",
+        "description": "설명"
+      },
+      "stats": {
+        "title": "동영상 통계",
+        "views": "조회수",
+        "likes": "좋아요",
+        "dislikes": "싫어요",
+        "comments": "댓글",
+        "rating": "평점",
+        "duration": "재생 시간"
+      },
+      "logs": {
+        "failure": "실패",
+        "errors": {
+          "count": "오류 ({count})",
+          "empty": "오류가 없습니다."
+        },
+        "warnings": {
+          "count": "경고 ({count})",
+          "empty": "경고가 없습니다."
+        },
+        "skipped": {
+          "count": "건너뛴 항목 ({count})",
+          "empty": "필터에 의해 건너뛴 항목이 없습니다.",
+          "items": "{count}개 항목 | {count}개 항목"
+        },
+        "all": {
+          "title": "전체 로그",
+          "empty": "로그가 없습니다."
+        },
+        "toasts": {
+          "reported": "오류가 신고되었습니다.",
+          "error": "오류를 신고할 수 없습니다."
+        }
+      }
+    },
+    "preferences": {
+      "badges": {
+        "override": "재정의"
+      },
+      "labels": {
+        "quality": "형식, 코덱, 트랙 우선순위를 선택하세요.",
+        "network": "프록시, 위장, 추출기 설정, 요청 헤더를 구성하세요. 이 다운로드에 한해 앱 기본값을 재정의합니다.",
+        "output": "컨테이너, 변환, 파일명 템플릿을 구성하세요. 이 다운로드에 한해 앱 기본값을 재정의합니다.",
+        "subtitles": "이 다운로드에 사용할 자막을 선택하세요.",
+        "headersOverride": "한 줄에 하나씩: FIELD:VALUE. 이 다운로드의 전역 헤더를 대체합니다."
+      },
+      "subtitles": {
+        "empty": "이 다운로드에서 사용할 수 있는 자막이 없습니다.",
+        "languages": {
+          "legend": "사용 가능한 언어",
+          "hint": "이 항목에서는 아래 자막만 다운로드할 수 있습니다.",
+          "manual": "제작자 제공",
+          "auto": "자동 생성",
+          "noneManual": "제작자가 제공한 자막이 없습니다.",
+          "noneAuto": "자동 생성 자막이 없습니다."
+        }
+      },
+      "hints": {
+        "format": "동영상 또는 오디오 품질을 선택하세요. 품질이 높을수록 파일 크기가 커지고 다운로드 시간이 길어집니다.",
+        "encodings": "선호하는 코덱을 선택하세요. 재생 호환성 유지나 원본 품질 보존에 유용합니다.",
+        "tracks": "더빙된 오디오 등 언어 또는 채널별 트랙이 있을 경우 선택하세요."
+      },
+      "tabs": {
+        "quality": "품질",
+        "subtitles": "자막",
+        "network": "네트워크"
+      }
+    },
+    "steps": {
+      "fetch": {
+        "progress": "{percentage}% — {total}개 중 {done}개",
+        "progressLabel": "메타데이터 가져오는 중…"
+      },
+      "configure": {
+        "format": {
+          "trackSelect": {
+            "screenReader": "다운로드할 트랙 선택"
+          },
+          "formatSelect": {
+            "noFormats": "형식 없음",
+            "placeholder": "형식 선택",
+            "screenReader": "트랙 형식 선택"
+          }
+        },
+        "encodings": {
+          "audioSelect": {
+            "noFormats": "오디오 인코딩 없음",
+            "placeholder": "오디오 코덱",
+            "screenReader": "오디오 인코딩 선택"
+          },
+          "videoSelect": {
+            "noFormats": "비디오 인코딩 없음",
+            "placeholder": "비디오 코덱",
+            "screenReader": "비디오 인코딩 선택"
+          }
+        },
+        "tracks": {
+          "availableInResolutions": "사용 가능한 해상도",
+          "unavailableForSelectedResolution": "선택한 해상도에서는 사용할 수 없음",
+          "audioSelect": {
+            "noFormats": "오디오 트랙 없음",
+            "placeholder": "오디오 트랙",
+            "screenReader": "오디오 트랙 선택"
+          },
+          "videoSelect": {
+            "noFormats": "비디오 트랙 없음",
+            "placeholder": "비디오 트랙",
+            "screenReader": "비디오 트랙 선택"
+          }
+        },
+        "metadata": {
+          "duration": "재생 시간: {duration}",
+          "size": "크기: ",
+          "sizeInfo": "다운로드될 데이터의 양입니다.\n최종 파일 크기가 아닙니다.",
+          "items": "항목: {amount}개 {details}",
+          "failedCount": "(실패 {amount}개)",
+          "skippedCount": "(건너뜀 {amount}개)",
+          "failedAndSkippedCount": "(실패 {failed}개, 건너뜀 {skipped}개)"
+        },
+        "trackTypes": {
+          "both": "영상 + 오디오",
+          "audio": "오디오",
+          "video": "영상"
+        }
+      },
+      "download": {
+        "progress": "{category} 다운로드 중… — {percentage}%",
+        "progressList": "다운로드 중… {percentage}% — {total}개 중 {done}개",
+        "indeterminate": "{status}…",
+        "category": {
+          "video": "영상",
+          "audio": "오디오",
+          "subtitles": "자막",
+          "thumbnail": "썸네일",
+          "metadata": "메타데이터",
+          "other": "기타"
+        },
+        "status": {
+          "initializing": "초기화 중",
+          "downloading": "다운로드 중",
+          "merging": "병합 중",
+          "remuxing": "리먹싱 중",
+          "reencoding": "재인코딩 중",
+          "finalizing": "정리 중"
+        },
+        "metadata": {
+          "eta": "예상 남은 시간: {eta}",
+          "speed": "속도: {speed}"
+        }
+      },
+      "paused": {
+        "progress": "다운로드 일시정지됨 — {percentage}%",
+        "progressList": "다운로드 일시정지됨 — {percentage}% — {total}개 중 {done}개",
+        "indeterminate": "다운로드 일시정지됨",
+        "metadata": {
+          "eta": "남은 시간: {eta}",
+          "etaItems": "남은 항목: {n}개 | 남은 항목: {n}개"
+        }
+      },
+      "done": {
+        "complete": "다운로드 완료 — 100%",
+        "showFolder": "폴더에서 보기",
+        "open": "파일 열기",
+        "openFirst": "첫 번째 파일 열기",
+        "undeterminedLocation": "이 항목의 다운로드 위치를 확인할 수 없습니다."
+      },
+      "error": {
+        "errorPrefix": "오류 - {message}",
+        "report": "신고",
+        "showFull": "로그 보기",
+        "signIn": "로그인",
+        "filters": "필터 편집"
+      }
+    },
+    "card": {
+      "actions": {
+        "remove": "제거",
+        "externalUrl": "외부 링크에서 보기",
+        "retry": "다운로드 재시도",
+        "download": "개별 다운로드",
+        "preferences": "다운로드 설정",
+        "pause": "다운로드 일시정지",
+        "resume": "다운로드 재개",
+        "metadata": "메타데이터 보기"
+      },
+      "toasts": {
+        "retry": "다운로드를 재시도합니다.",
+        "retryError": "다운로드를 재시도할 수 없습니다."
+      }
+    }
+  },
+  "subtitles": {
+    "title": "자막",
+    "defaults": {
+      "legend": "자막 기본값",
+      "hint": "동영상에 자막이 있을 때 사용됩니다."
+    },
+    "options": {
+      "enable": {
+        "legend": "자막 다운로드",
+        "legendLabel": "기본 자막 설정을 선택하세요.",
+        "label": "자막 사용",
+        "hint": "사용 가능한 경우 자막을 다운로드합니다."
+      },
+      "autoGenerated": {
+        "label": "자동 생성 자막 다운로드",
+        "hint": "사용 가능한 경우 자동 생성 자막도 다운로드합니다."
+      },
+      "format": {
+        "legend": "선호 형식",
+        "legendLabel": "선호하는 자막 형식을 선택하세요. 해당 형식을 사용할 수 없으면 차선 형식이 사용됩니다.",
+        "label": "형식"
+      },
+      "embed": {
+        "label": "자막 트랙 추가:",
+        "hint": "동영상 파일에 자막을 추가합니다. mp4, mkv, webm 형식에서 동작합니다."
+      },
+      "languages": {
+        "legend": "언어",
+        "legendLabel": "선호하는 자막 언어를 선택하세요.",
+        "downloadAll": "사용 가능한 모든 자막 다운로드.",
+        "search": "언어 검색",
+        "searchPlaceholder": "언어 이름으로 검색",
+        "noResult": "\"{query}\"와(과) 일치하는 언어가 없습니다.",
+        "selected": "선택됨:",
+        "none": "없음",
+        "allSelected": "사용 가능한 모든 자막"
+      }
+    },
+    "toasts": {
+      "saved": "자막 설정이 저장되었습니다!",
+      "error": "자막 설정을 저장할 수 없습니다. {error}"
+    },
+    "formats": {
+      "srt": "SubRip (.srt)",
+      "vtt": "WebVTT (.vtt)",
+      "ass": "Advanced SubStation Alpha (.ass)",
+      "ttml": "Timed Text Markup (.ttml)",
+      "json3": "JSON (.json)"
+    }
+  },
+  "location": {
+    "title": "다운로드 위치",
+    "downloadDir": {
+      "label": "다운로드 위치",
+      "hint": "동영상이 다운로드될 위치를 선택하려면 상자를 클릭하세요."
+    },
+    "directory": {
+      "legend": "정리 방식",
+      "legendLabel": "다운로드를 폴더별로 정리하는 방식을 선택하세요.",
+      "videoDir": {
+        "label": "다운로드 위치:",
+        "hint": "동영상을 다운로드할 때 전역 다운로드 위치를 재정의합니다."
+      },
+      "audioDir": {
+        "label": "다운로드 위치:",
+        "hint": "오디오를 다운로드할 때 전역 다운로드 위치를 재정의합니다."
+      },
+      "directoryPreset": {
+        "label": "다운로드 정리 방식:",
+        "exampleLabel": "출력 예시:",
+        "options": {
+          "none": "하위 폴더 없음",
+          "playlist": "재생목록",
+          "channel": "채널",
+          "channelPlaylist": "채널 → 재생목록",
+          "yearMonth": "연도 / 월",
+          "artistAlbum": "아티스트 → 앨범",
+          "custom": "사용자 지정"
+        },
+        "examples": {
+          "playlist": "내 재생목록/",
+          "channel": "내채널/",
+          "channelPlaylist": "내채널/내 재생목록/",
+          "yearMonth": "2025/03/",
+          "artistAlbum": "아티스트 이름/앨범 이름/"
+        }
+      },
+      "outputFormat": {
+        "label": "디렉터리 형식:"
+      }
+    },
+    "filename": {
+      "legend": "파일명 형식",
+      "legendLabel": "다운로드에 사용할 파일명을 선택하세요.",
+      "reversePlaylistNumbering": {
+        "label": "재생목록 번호 역순:",
+        "hint": "처음이 아닌 끝에서부터 재생목록 항목 번호를 매깁니다."
+      },
+      "formatPreset": {
+        "label": "파일명 프리셋:",
+        "exampleLabel": "출력 예시:",
+        "options": {
+          "titleQuality": "제목 + 품질",
+          "titleOnly": "제목만",
+          "titleQualityPlaylist": "재생목록 + 제목 + 품질",
+          "custom": "사용자 지정"
+        },
+        "examples": {
+          "video": {
+            "titleQuality": "내 동영상-(1080p30).mp4",
+            "titleOnly": "내 동영상.mp4",
+            "titleQualityPlaylist": "03-내 동영상-(1080p30).mkv"
+          },
+          "audio": {
+            "titleQuality": "내 오디오-(320k).mp3",
+            "titleOnly": "내 오디오.mp3",
+            "titleQualityPlaylist": "03-내 오디오-(320k).mp3"
+          }
+        },
+        "restrictFilenames": {
+          "label": "파일명 제한:",
+          "hint": "파일명의 공백을 밑줄로 바꾸고 \"&\" 같은 특수문자를 제거합니다."
+        }
+      },
+      "outputFormat": {
+        "label": "파일명 형식:"
+      }
+    },
+    "toasts": {
+      "saved": "저장 위치가 저장되었습니다!",
+      "error": "저장 위치를 저장할 수 없습니다."
+    }
+  },
+  "inputFilters": {
+    "title": "입력 필터",
+    "filesize": {
+      "legend": "파일 크기",
+      "hint": "선택한 크기보다 크거나 작은 항목만 유지합니다."
+    },
+    "dates": {
+      "legend": "업로드 날짜",
+      "hint": "특정 날짜에, 이전에, 또는 이후에 업로드된 항목만 유지합니다."
+    },
+    "advanced": {
+      "legend": "고급 필터",
+      "hint": "고급 사용을 위한 원본 yt-dlp 필터입니다."
+    },
+    "fields": {
+      "minSize": {
+        "label": "최소 파일 크기:"
+      },
+      "maxSize": {
+        "label": "최대 파일 크기:"
+      },
+      "size": {
+        "valuePlaceholder": "50",
+        "unitPlaceholder": "단위"
+      },
+      "date": {
+        "modeLabel": "일치 규칙",
+        "clearMode": "끄기",
+        "hint": "날짜 규칙을 선택한 다음 날짜를 선택하세요.",
+        "mode": {
+          "exact": "해당 날짜",
+          "before": "해당 날짜 또는 이전",
+          "after": "해당 날짜 또는 이후"
+        },
+        "activeLabel": {
+          "exact": "이 날짜에 업로드된 동영상",
+          "before": "이 날짜 또는 이전에 업로드된 동영상",
+          "after": "이 날짜 또는 이후에 업로드된 동영상"
+        },
+        "presetsLabel": "빠른 선택",
+        "presets": {
+          "today": "오늘",
+          "yesterday": "어제",
+          "last7Days": "최근 7일",
+          "last30Days": "최근 30일"
+        }
+      },
+      "matchFilters": {
+        "label": "일치 필터:",
+        "placeholder": "!is_live & view_count >=? 10000",
+        "hint": "예시: !is_live, duration >? 600, like_count >=? 100"
+      },
+      "breakMatchFilters": {
+        "label": "중단 필터:",
+        "placeholder": "duration >? 3600",
+        "hint": "현재 링크가 이 필터에서 실패하면 확인을 중단합니다."
+      }
+    },
+    "playlistSelection": {
+      "title": "재생목록 항목 선택",
+      "description": "다운로드할 항목을 선택하세요:",
+      "selectionSummary": "{total}개 중 {count}개 항목 선택됨 | {total}개 중 {count}개 항목 선택됨",
+      "selectionSummaryAll": "모든 항목 선택됨 | 전체 {count}개 항목 선택됨",
+      "advancedButton": "고급",
+      "simpleButton": "초기화",
+      "advancedTitle": "고급 재생목록 선택",
+      "advancedHint": "여러 항목, 음수, 여러 범위를 선택할 수 있습니다.",
+      "advancedDescription": "현재 선택 항목",
+      "advancedEmpty": "아직 설정된 고급 선택 항목이 없습니다.",
+      "addSingle": "항목 추가",
+      "addRange": "범위 추가",
+      "applyFull": "모든 항목 다운로드",
+      "applySelection": "선택한 항목 다운로드",
+      "useAdvanced": "고급 선택 사용",
+      "noMatches": "이 범위와 일치하는 항목이 재생목록에 없습니다.",
+      "row": {
+        "single": "단일",
+        "range": "범위"
+      },
+      "remove": "제거",
+      "fields": {
+        "advancedLabel": "고급:",
+        "index": "항목",
+        "indexPlaceholder": "1 또는 -1",
+        "start": "시작",
+        "startPlaceholder": "1",
+        "end": "끝",
+        "endPlaceholder": "10",
+        "input": "항목"
+      },
+      "errors": {
+        "playlistIndex": "0이 아닌 정수를 입력하세요. 음수는 끝에서부터 셉니다.",
+        "playlistRangeBounds": "시작과 끝을 설정하세요. 음수는 끝에서부터 셉니다."
+      }
+    },
+    "toasts": {
+      "saved": "입력 필터가 저장되었습니다!",
+      "error": "입력 필터를 저장할 수 없습니다. {error}"
+    }
+  },
+  "settings": {
+    "title": "설정",
+    "reset": {
+      "label": "초기화",
+      "confirm": "다시 클릭하면 초기화됩니다"
+    },
+    "tabs": {
+      "downloads": "다운로드",
+      "app": "앱",
+      "network": "네트워크",
+      "system": "시스템",
+      "about": "정보"
+    },
+    "performance": {
+      "legend": "성능",
+      "legendLabel": "사용할 시스템 리소스를 구성하세요.",
+      "maxConcurrency": {
+        "label": "최대 동시 작업 수:"
+      },
+      "splitPlaylistThreshold": {
+        "label": "재생목록을 개별 동영상으로 분할하는 기준:",
+        "options": {
+          "never": "분할 안 함",
+          "lessThan": "{number}개 미만"
+        }
+      },
+      "autoLoadSize": {
+        "label": "동영상 크기 자동 불러오기:"
+      }
+    },
+    "input": {
+      "legend": "입력",
+      "legendLabel": "OVD로 다운로드를 시작하는 방식을 선택하세요.",
+      "autoFillClipboard": {
+        "label": "복사한 링크 자동 입력:",
+        "hint": "복사한 링크를 감지하여 한 번의 클릭으로 다운로드할 수 있습니다."
+      },
+      "preferVideoInMixedLinks": {
+        "label": "재생목록 링크에서 단일 동영상 우선:",
+        "hint": "링크에 동영상과 재생목록이 모두 포함된 경우, 전체 재생목록 대신 해당 동영상만 다운로드합니다."
+      },
+      "globalShortcuts": {
+        "label": "단축키 사용:",
+        "add_hint": "다음 키로 동영상을 대기열에 추가:",
+        "download_hint": "다음 키로 대기열 다운로드:",
+        "instant_hint": "다음 키로 즉시 추가 및 다운로드:"
+      },
+      "authentication": {
+        "label": "비공개 동영상을 다운로드하려면 로그인:",
+        "link": "인증 설정"
+      }
+    },
+    "output": {
+      "legend": "출력",
+      "legendLabel": "다운로드할 파일의 종류를 구성하세요.",
+      "addThumbnail": {
+        "label": "표지 이미지 추가:",
+        "hint": "미디어 플레이어가 아트워크를 표시할 수 있도록 파일 안에 썸네일을 삽입합니다."
+      },
+      "saveThumbnail": {
+        "label": "썸네일 파일 저장:",
+        "hint": "미디어 파일 옆에 사용 가능한 최고 화질의 썸네일을 다운로드합니다."
+      },
+      "addMetadata": {
+        "label": "제목 및 아티스트 정보 추가:",
+        "hint": "제목, 업로더/아티스트, 설명 등의 메타데이터를 파일 안에 저장합니다."
+      },
+      "preciseCuts": {
+        "label": "정밀 자르기:",
+        "hint": "가까운 키프레임이 아닌 정확한 프레임에서 자릅니다. 매우 느립니다.\n일반 자르기가 잘못되거나, 깨지거나, 화면이 검게 나오거나 일부가 누락될 때만 사용하세요."
+      },
+      "partialDownload": {
+        "legend": "부분 다운로드",
+        "hint": "일부만 다운로드하도록 타임스탬프 또는 챕터를 설정하세요.",
+        "use": "사용",
+        "useTimes": "타임스탬프",
+        "useChapter": "챕터",
+        "chapter": "챕터",
+        "startAt": "시작 지점",
+        "stopAt": "종료 지점",
+        "invalidHint": "잘못된 타임스탬프는 무시됩니다.",
+        "allChapters": "모든 챕터",
+        "errors": {
+          "invalid": "올바른 시간을 입력하세요.",
+          "beforeStart": "종료 시간은 시작 시간보다 뒤여야 합니다.",
+          "exceedsDuration": "타임스탬프는 동영상 재생 시간을 초과할 수 없습니다."
+        }
+      },
+      "location": {
+        "label": "다운로드 위치 및 파일명:",
+        "link": "다운로드 위치 설정"
+      },
+      "subtitles": {
+        "label": "자막 추가:",
+        "link": "자막 설정"
+      },
+      "keepOriginalStreams": {
+        "label": "원본 스트림 유지",
+        "hint": "선택한 후처리 단계에서 필요로 하지 않는 한 컨테이너 변환 및 재인코딩을 피합니다."
+      },
+      "postprocess": {
+        "label": "동영상 후처리:",
+        "hint": "후처리는 다운로드가 끝난 후에 실행됩니다.",
+        "reencodeWarning": "이 옵션은 재인코딩을 수행하며, 부하가 크고 시간이 오래 걸릴 수 있습니다.",
+        "keepOriginalStreamsConflict": "이 옵션을 사용하려면 재인코딩이 필요합니다. 사용하려면 원본 스트림 유지를 비활성화하세요.",
+        "mp42RequiresMp4": "이 옵션을 사용하려면 mp4 출력이 필요합니다.",
+        "options": {
+          "none": "없음",
+          "fps30": "30fps로 재인코딩",
+          "mp42": "mp4 브랜드를 mp42로 설정",
+          "custom": "사용자 지정"
+        }
+      },
+      "postprocessMode": {
+        "label": "사용자 지정 후처리 모드:",
+        "hint": "사용자 지정 ffmpeg 인수가 리먹싱 중에 실행될지, 재인코딩 중에 실행될지 선택하세요.",
+        "options": {
+          "remux": "리먹싱 중에 실행",
+          "reencode": "재인코딩 중에 실행"
+        }
+      },
+      "postprocessArgs": {
+        "label": "고급 ffmpeg 인수:",
+        "hint": "고급 사용자 전용입니다. 인수는 공백으로 구분하며, 따옴표로 묶인 값은 그대로 유지됩니다."
+      },
+      "tabs": {
+        "audio": {
+          "screenreader": "오디오 설정",
+          "label": "오디오",
+          "format": {
+            "label": "오디오 형식:",
+            "hint": "선호하는 오디오 형식을 선택하세요.",
+            "options": {
+              "mp3": "MP3 (권장)",
+              "m4a": "M4A",
+              "ogg": "OGG",
+              "aac": "AAC",
+              "opus": "Opus",
+              "wav": "WAV",
+              "flac": "FLAC"
+            }
+          },
+          "postprocess": {
+            "label": "오디오 후처리:",
+            "options": {
+              "none": "없음",
+              "custom": "사용자 지정"
+            }
+          }
+        },
+        "video": {
+          "screenreader": "동영상 설정",
+          "label": "동영상",
+          "container": {
+            "label": "동영상 형식:",
+            "hint": "선호하는 동영상 컨테이너를 선택하세요.",
+            "options": {
+              "mp4": "MP4",
+              "mkv": "MKV"
+            }
+          }
+        }
+      }
+    },
+    "appearance": {
+      "legend": "화면",
+      "legendLabel": "앱의 모양과 느낌을 구성하세요.",
+      "theme": {
+        "label": "테마:",
+        "options": {
+          "system": "시스템 ({theme})",
+          "light": "밝게",
+          "dark": "어둡게"
+        }
+      },
+      "language": {
+        "label": "언어:",
+        "options": {
+          "system": "시스템 ({language})"
+        }
+      },
+      "expandedOptions": {
+        "label": "추가 선택기:",
+        "hint": "다운로드 전에 표시할 추가 선택기를 선택하세요.",
+        "options": {
+          "none": "없음",
+          "encodings": "인코딩",
+          "tracks": "트랙"
+        }
+      }
+    },
+    "network": {
+      "legend": "네트워크",
+      "legendLabel": "앱이 인터넷에 연결하는 방식을 구성하세요.",
+      "enableProxy": {
+        "label": "프록시로 연결:"
+      },
+      "proxy": {
+        "label": "프록시 설정:"
+      },
+      "impersonate": {
+        "label": "위장:",
+        "hint": "핑거프린팅을 방지하기 위해 특정 OS 또는 브라우저로 위장합니다.",
+        "options": {
+          "none": "위장하지 않음",
+          "any": "무작위 클라이언트로 위장"
+        }
+      },
+      "extractorArgs": {
+        "label": "추출기 인수:",
+        "hint": "yt-dlp의 추출기 인수를 사용자 지정합니다. 한 줄에 하나씩 입력하세요.",
+        "placeholder": "youtube:player_js_variant=main",
+        "flagWarning": "값만 입력하세요. 앱이 자동으로 --extractor-args를 추가합니다."
+      }
+    },
+    "sponsorBlock": {
+      "legend": "SponsorBlock",
+      "legendLabel": "동영상의 특정 구간을 제거하거나 표시합니다.",
+      "removeParts": {
+        "label": "제거할 구간:",
+        "placeholder": "동영상에서 제거할 구간을 1개 이상 선택하세요."
+      },
+      "markParts": {
+        "label": "표시할 구간:",
+        "placeholder": "챕터로 표시할 구간을 1개 이상 선택하세요."
+      },
+      "apiUrl": {
+        "label": "API URL:"
+      },
+      "preciseCuts": {
+        "label": "정밀 자르기:",
+        "hint": "SponsorBlock 제거 및 부분 다운로드가 정확한 프레임에서 잘리도록 합니다. 매우 느립니다.\n일반 자르기가 잘못되거나, 깨지거나, 화면이 검게 나오거나 일부가 누락될 때만 사용하세요."
+      },
+      "parts": {
+        "sponsor": {
+          "label": "스폰서",
+          "description": "제작자 또는 제3자의 유료 제품/서비스 홍보."
+        },
+        "selfpromo": {
+          "label": "자체 홍보 / 무료",
+          "description": "제작자 본인의 상품, 서비스, 채널 홍보(무료)."
+        },
+        "interaction": {
+          "label": "상호작용 요청",
+          "description": "좋아요/구독/팔로우 또는 제작자와의 상호작용을 요청하는 구간."
+        },
+        "intro": {
+          "label": "인트로 / 중간 광고",
+          "description": "시작 부분의 인트로 애니메이션, 중간 광고, 또는 본편과 무관한 정지 구간."
+        },
+        "outro": {
+          "label": "아웃트로 / 엔드카드 / 크레딧",
+          "description": "끝부분의 엔드카드, 크레딧, 또는 마무리 구간."
+        },
+        "hook": {
+          "label": "훅 / 인사말",
+          "description": "다음 영상 예고 나레이션, 인사말과 작별 인사."
+        },
+        "music_offtopic": {
+          "label": "음악 외 구간",
+          "description": "음악 동영상 속 대화나 잡담 구간."
+        },
+        "preview": {
+          "label": "미리보기 / 요약",
+          "description": "이후 내용 미리보기 또는 이전 구간 요약."
+        },
+        "filler": {
+          "label": "군더더기 / 잡담",
+          "description": "본편 이해에 불필요한 잡담, 농담, 또는 군더더기 장면."
+        },
+        "chapter": {
+          "label": "챕터",
+          "description": "동영상의 챕터/구간 표시(챕터 작업 유형과 함께 사용)."
+        }
+      }
+    },
+    "update": {
+      "legend": "업데이트",
+      "legendLabel": "자동으로 업데이트할 앱의 구성 요소를 선택하세요.",
+      "updateBinaries": {
+        "label": "도구 자동 업데이트:",
+        "hint": "OVD는 yt-dlp, ffmpeg 같은 도구를 사용해 동영상을 다운로드합니다. 이 옵션을 사용하면 최신 상태로 유지됩니다."
+      },
+      "updateApp": {
+        "label": "앱 자동 업데이트:",
+        "hint": "새 버전이 출시되는 즉시 새로운 기능과 버그 수정을 받으려면 이 옵션을 켜세요."
+      }
+    },
+    "system": {
+      "legend": "시스템",
+      "legendLabel": "이 앱이 시스템과 통합되는 방식을 구성하세요.",
+      "trayEnabled": {
+        "label": {
+          "mac": "메뉴 막대 아이콘 표시",
+          "generic": "시스템 트레이 아이콘 표시"
+        },
+        "hint": {
+          "mac": "빠른 접근을 위해 메뉴 막대에 아이콘을 표시합니다.",
+          "generic": "빠른 접근을 위해 시스템 트레이에 아이콘을 표시합니다."
+        }
+      },
+      "minimiseToTray": {
+        "label": "닫을 때 트레이로 최소화",
+        "hint": "창을 닫으면 앱이 종료되지 않고 시스템 트레이에 숨겨집니다."
+      },
+      "autoStart": {
+        "label": "로그인 시 자동 시작",
+        "hint": "로그인할 때 Open Video Downloader를 자동으로 실행합니다."
+      },
+      "autoStartMinimised": {
+        "label": {
+          "mac": "로그인 시 숨김 상태로 시작",
+          "windows": "로그인 시 트레이로 최소화된 상태로 시작",
+          "generic": "로그인 시 숨김 상태로 시작(권장하지 않음)"
+        },
+        "hint": {
+          "mac": "앱이 로그인 시 시작될 때 창이 열리지 않습니다. 메뉴 막대나 Dock 아이콘을 이용해 여세요.",
+          "windows": "앱이 로그인 시 시작될 때 창을 열지 않고 시스템 트레이에서 시작됩니다.",
+          "generic": "앱이 로그인 시 시작될 때 창이 열리지 않습니다."
+        }
+      }
+    },
+    "notifications": {
+      "legend": "알림",
+      "legendLabel": "알림을 보낼 시점을 구성하세요.",
+      "behavior": {
+        "label": "알림 표시:",
+        "options": {
+          "always": "항상",
+          "onBackground": "백그라운드에 있을 때",
+          "never": "표시 안 함"
+        },
+        "hint": "팁: 단축키와 함께 앱을 사용할 때 알림이 유용할 수 있습니다."
+      },
+      "disabled": {
+        "label": "특정 알림 사용/사용 안 함",
+        "disabledScreenReader": "이 옵션은 비활성화되어 있습니다.",
+        "kinds": {
+          "queueAdded": "대기열에 추가됨",
+          "queueDownloading": "대기열 다운로드 중",
+          "queueFinished": "대기열 완료",
+          "videoFinished": "동영상 완료",
+          "playlistFinished": "재생목록 완료",
+          "downloadFailed": "다운로드 실패",
+          "videoReady": "동영상 준비됨",
+          "playlistReady": "재생목록 준비됨"
+        }
+      }
+    },
+    "toasts": {
+      "saved": "설정이 저장되었습니다!",
+      "reset": "설정을 기본값으로 초기화했습니다."
+    }
+  },
+  "updater": {
+    "available": "업데이트가 있습니다!",
+    "install": {
+      "title": "업데이트 설치",
+      "subtitle": "앱이 다시 시작됩니다."
+    },
+    "downloading": "업데이트 다운로드 중…"
+  },
+  "install": {
+    "title": {
+      "installing": "필수 도구 설치 중…",
+      "failed": "일부 필수 도구를 설치하지 못했습니다.",
+      "installed": "필수 도구를 설치했습니다."
+    },
+    "subtitle": {
+      "installing": "준비 중입니다.",
+      "failed": "앱이 예상대로 동작하지 않을 수 있습니다. 이 문제를 신고해 주세요.",
+      "installed": "다운로드할 준비가 되었습니다!"
+    }
+  },
+  "components": {
+    "base": {
+      "emptyState": {
+        "title": "대기열이 비어 있습니다",
+        "subtitle": "동영상을 추가하여 시작하세요."
+      },
+      "dragState": {
+        "title": "놓아서 대기열에 추가",
+        "subtitle": "동영상이나 링크가 담긴 파일을 드래그하여 대기열에 추가하세요."
+      },
+      "fileInput": {
+        "select": "파일 선택",
+        "placeholder": "파일 선택…",
+        "invalid": "유효하지 않은 파일입니다.",
+        "clear": "파일 지우기",
+        "recents": {
+          "clear": "최근 파일 지우기",
+          "open": "최근 선택 항목 열기",
+          "empty": "최근 선택 항목 없음"
+        }
+      },
+      "folderInput": {
+        "select": "폴더 선택",
+        "placeholder": "폴더 선택…",
+        "invalid": "유효하지 않은 폴더입니다.",
+        "clear": "폴더 지우기",
+        "recents": {
+          "clear": "최근 폴더 지우기",
+          "open": "최근 선택 항목 열기",
+          "empty": "최근 선택 항목 없음"
+        }
+      },
+      "secretInput": {
+        "hide": "숨기기",
+        "show": "표시",
+        "clear": "{label} 지우기"
+      },
+      "toolCard": {
+        "failed": "이 도구를 설치하지 못했습니다. 더 많은 정보를 보려면 펼치세요."
+      }
+    }
+  },
+  "errors": {
+    "runner": {
+      "internal": {
+        "shortMessage": "내부 오류",
+        "message": "이 항목을 처리하는 중 내부 오류가 발생했습니다."
+      },
+      "signInRequired": {
+        "shortMessage": "로그인 필요",
+        "message": "이 콘텐츠를 보려면 로그인해야 합니다."
+      },
+      "membersOnly": {
+        "shortMessage": "멤버 전용",
+        "message": "이 동영상은 채널 멤버만 볼 수 있습니다."
+      },
+      "geoBlocked": {
+        "shortMessage": "지역 차단됨",
+        "message": "이 콘텐츠는 사용자의 지역에서 이용할 수 없습니다."
+      },
+      "accessForbidden403": {
+        "shortMessage": "접근 거부됨",
+        "message": "이 리소스에 접근할 권한이 없습니다(HTTP 403)."
+      },
+      "notFound404": {
+        "shortMessage": "찾을 수 없음",
+        "message": "요청한 동영상이나 재생목록을 찾을 수 없습니다(HTTP 404)."
+      },
+      "server5xx": {
+        "shortMessage": "서버 오류",
+        "message": "일시적인 서버 문제가 발생했습니다. 나중에 다시 시도하세요."
+      },
+      "rateLimited429": {
+        "shortMessage": "요청 제한됨",
+        "message": "너무 많은 요청이 전송되었습니다. 잠시 후 다시 시도하세요."
+      },
+      "requestedFormatUnavailable": {
+        "shortMessage": "형식 사용 불가",
+        "message": "선택한 형식은 이 동영상에서 사용할 수 없습니다."
+      },
+      "unableToExtractInitialData": {
+        "shortMessage": "데이터 추출 실패",
+        "message": "필요한 초기 동영상 데이터를 추출하지 못했습니다."
+      },
+      "unableToExtractIdOrInfo": {
+        "shortMessage": "메타데이터 오류",
+        "message": "동영상 또는 업로더 정보를 추출하지 못했습니다."
+      },
+      "nsigExtractionFailed": {
+        "shortMessage": "서명 실패",
+        "message": "동영상 서명을 추출하거나 해독하지 못했습니다."
+      },
+      "embedOnly": {
+        "shortMessage": "임베드 전용 동영상",
+        "message": "이 동영상은 임베드된 플레이어를 통해서만 접근할 수 있습니다."
+      },
+      "urlUnsupported": {
+        "shortMessage": "유효하지 않은 링크",
+        "message": "제공된 링크는 지원되지 않거나 인식되지 않습니다."
+      },
+      "unknownUrlType": {
+        "shortMessage": "알 수 없는 링크 유형",
+        "message": "제공된 링크가 지원되지 않는 프로토콜을 사용합니다."
+      },
+      "networkNameResolutionFailed": {
+        "shortMessage": "네트워크 오류",
+        "message": "호스트 이름을 확인할 수 없습니다. 인터넷 연결을 확인하세요."
+      },
+      "unableToConnectToProxy": {
+        "shortMessage": "프록시 연결 실패",
+        "message": "프록시에 연결할 수 없습니다. 프록시 설정을 확인하세요."
+      },
+      "signInRequiredForBotDetection": {
+        "shortMessage": "로그인 필요",
+        "message": "봇이 아님을 확인하려면 로그인하세요."
+      },
+      "playlistPrivateOrMissing": {
+        "shortMessage": "재생목록을 사용할 수 없음",
+        "message": "이 재생목록은 비공개이거나 더 이상 존재하지 않습니다."
+      },
+      "videoNotFoundOrPrivate": {
+        "shortMessage": "동영상을 사용할 수 없음",
+        "message": "이 동영상은 삭제되었거나 비공개로 전환되었습니다."
+      },
+      "channelUnavailable": {
+        "shortMessage": "채널을 사용할 수 없음",
+        "message": "이 콘텐츠를 호스팅하는 채널에 더 이상 접근할 수 없습니다."
+      },
+      "ffmpegNotFound": {
+        "shortMessage": "ffmpeg를 찾을 수 없음",
+        "message": "mp3나 mp4로 변환하려면 ffmpeg가 필요합니다."
+      },
+      "ffmpegFailed": {
+        "shortMessage": "ffmpeg 실패",
+        "message": "처리 중 FFmpeg에서 오류가 발생했습니다."
+      },
+      "rejectedByFilter": {
+        "shortMessage": "필터링됨",
+        "message": "이 항목은 입력 필터에 의해 거부되었습니다."
+      },
+      "cannotAllocateMemory": {
+        "shortMessage": "메모리 오류",
+        "message": "동영상 처리 중 FFmpeg의 메모리가 부족해졌습니다."
+      },
+      "permissionDenied": {
+        "shortMessage": "권한 거부됨",
+        "message": "앱에 이 파일이나 폴더에 접근할 권한이 없습니다."
+      },
+      "noWritePermission": {
+        "shortMessage": "쓸 수 없음",
+        "message": "대상 경로에 쓸 수 없습니다."
+      },
+      "windowsFileMissing": {
+        "shortMessage": "파일 없음",
+        "message": "참조된 파일을 찾을 수 없습니다(WinError 2)."
+      },
+      "blockedGeneric": {
+        "shortMessage": "동영상 차단됨",
+        "message": "이 동영상은 차단되어 다운로드할 수 없습니다."
+      },
+      "copyrightClaimed": {
+        "shortMessage": "저작권 차단",
+        "message": "저작권 침해 신고로 인해 이 동영상이 차단되었습니다."
+      },
+      "notPremieredYet": {
+        "shortMessage": "아직 프리미어 공개 전",
+        "message": "이 동영상은 프리미어가 시작되기 전까지 이용할 수 없습니다."
+      },
+      "livestreamNotStarted": {
+        "shortMessage": "라이브 스트림 대기 중",
+        "message": "라이브 스트림이 아직 시작되지 않았습니다. 나중에 다시 확인하세요."
+      },
+      "sslVerifyFailed": {
+        "shortMessage": "SSL 실패",
+        "message": "보안 연결을 확인할 수 없습니다. 인증서나 날짜/시간을 확인하세요."
+      },
+      "sponsorBlockUnreachable": {
+        "shortMessage": "SponsorBlock 연결 안 됨",
+        "message": "구간 데이터를 위해 SponsorBlock API에 연결할 수 없습니다."
+      },
+      "downloadRetryingFragment": {
+        "shortMessage": "조각 재시도 중",
+        "message": "조각 다운로드에 실패하여 자동으로 재시도합니다."
+      },
+      "unknown": {
+        "shortMessage": "알 수 없는 오류",
+        "message": "이 항목을 처리하는 중 알 수 없는 오류가 발생했습니다."
+      }
+    }
+  },
+  "about": {
+    "title": "정보",
+    "credit": "jely2002 및 기여자가 ❤로 만듦",
+    "poweredBy": "오픈소스로 제작됨:",
+    "viewLicenses": "라이선스 보기",
+    "version": "버전: {version}",
+    "links": {
+      "github": "GitHub",
+      "wiki": "위키",
+      "reportABug": "버그 신고"
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

This adds Korean (`ko`) translation support — to help Korean-speaking users use this
open-source project more comfortably in their own language.
(한국 사람들의 오픈소스 이용에 도움이 되게 하기 위해서 한글화 작업을 하였습니다.)

## Changes

- Add `src/locales/ko.json` — full Korean translation of the front-end UI (647 keys, matching `en.json` exactly).
- Add `src-tauri/locales/ko.json` — full Korean translation of the back-end tray menu and notifications (27 keys, matching `en.json` exactly).
- Keyboard shortcut labels (e.g. `Ctrl + Shift + V`) are left untranslated, matching the existing convention used by most other locales (ru, tr, zh-TW).
- No keys renamed, no JSON structure changed, and all placeholders (`{title}`, `{n}`, `{percent}`, `{error}`, etc.) and pluralization (`|`) forms preserved exactly.

## Testing

- Verified full key parity between `en.json` and the new `ko.json` files for both locale folders (647/647 front-end keys, 27/27 back-end keys, 0 missing/extra) with a script.
- Verified every placeholder and pluralization (`|`) segment count matches the English source string-by-string.
- `npm run lint` passes with no errors.
- `npx vue-tsc --noEmit` passes with no errors.
- `npx vitest run` — all 127 existing unit tests across 31 files pass.
- Did not run the full Tauri app in dev mode (requires the native Rust/Tauri toolchain, not available in this environment), so the translated strings have not been visually verified inside the running UI.